### PR TITLE
Point the home meta-data at the public repo

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -40,7 +40,7 @@ test:
     - python -m unittest tests
 
 about:
-  home: https://git.autodesk.com/Research/occwl
+  home: https://github.com/AutodeskAILab/occwl
   license: BSD
   license_family: BSD
   summary: Lightweight Pythonic wrapper around pythonocc


### PR DESCRIPTION
The url on the [conda package page](https://anaconda.org/lambouj/occwl) is out of date.  Let's point this at the public repo 