### PR TITLE
Add support for compound solids.   Move reversed() to Shape

### DIFF
--- a/src/occwl/compound.py
+++ b/src/occwl/compound.py
@@ -1,0 +1,14 @@
+from occwl.solid import Solid
+
+
+class Compound(Solid):
+    """
+    A compound which can be worked with as many solids
+    lumped together.
+    """
+    def __init__(self, shape):
+        assert isinstance(shape, TopoDS_Compound) or isinstance(shape, TopoDS_CompSolid)
+        super().__init__(shape, allow_compound=True)
+        
+    def solids(self):
+        return map(Face, self._top_exp.solids())

--- a/src/occwl/compound.py
+++ b/src/occwl/compound.py
@@ -1,3 +1,19 @@
+from OCC.Core.TopoDS import (
+    topods,
+    TopoDS_Wire,
+    TopoDS_Vertex,
+    TopoDS_Edge,
+    TopoDS_Face,
+    TopoDS_Shell,
+    TopoDS_Solid,
+    TopoDS_Shape,
+    TopoDS_Compound,
+    TopoDS_CompSolid,
+    topods_Edge,
+    topods_Vertex,
+    TopoDS_Iterator,
+)
+
 from occwl.solid import Solid
 
 
@@ -7,8 +23,10 @@ class Compound(Solid):
     lumped together.
     """
     def __init__(self, shape):
-        assert isinstance(shape, TopoDS_Compound) or isinstance(shape, TopoDS_CompSolid)
+        assert (isinstance(shape, TopoDS_Solid) or 
+                isinstance(shape, TopoDS_Compound) or 
+                isinstance(shape, TopoDS_CompSolid))
         super().__init__(shape, allow_compound=True)
         
     def solids(self):
-        return map(Face, self._top_exp.solids())
+        return map(Solid, self._top_exp.solids())

--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -373,14 +373,6 @@ class Edge(Shape):
             self.topods_shape(), face1.topods_shape(), face2.topods_shape()
         )
 
-    def reversed(self):
-        """
-        Whether this edge is reversed with respect to the curve geometry
-
-        Returns:
-            bool: If rational
-        """
-        return self.topods_shape().Orientation() == TopAbs_REVERSED
 
     def curve_type(self):
         """

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -246,11 +246,6 @@ class Face(Shape):
             return srf.BSpline()
         raise ValueError("Unknown surface type: ", surf_type)
 
-    def reversed(self):
-        """
-        Returns if the orientation of the face is reversed i.e. TopAbs_REVERSED
-        """
-        return self.topods_shape().Orientation() == TopAbs_REVERSED
 
     def point(self, uv):
         """

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -34,6 +34,7 @@ def load_single_compound_from_step(step_filename):
     reader.ReadFile(step_filename_str)
     reader.TransferRoots()
     shape = reader.OneShape()
+    return Compound(shape)
 
 def load_step(step_filename):
     """Load solids from a STEP file

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -1,4 +1,5 @@
 from OCC.Core.STEPControl import STEPControl_Reader
+from occwl.compound import Compound
 from occwl.solid import Solid
 from occwl.face import Face
 from occwl.edge import Edge
@@ -12,14 +13,16 @@ from OCC.Core.IFSelect import IFSelect_RetDone
 
 from pathlib import Path
 
-def load_step(step_filename):
-    """Load solids from a STEP file
+def load_single_compound_from_step(step_filename):
+    """
+    Load data from a STEP file as a single compound
 
     Args:
         step_filename (str): Path to STEP file
 
     Returns:
-        List of occwl.Solid: a list of solid models from the file
+        List of occwl.Compound: a single compound containing all shapes in
+                                the file
     """
     # Check that the file exists.  OCC can crash if the file isn't there
     step_filename_path = Path(step_filename)
@@ -31,11 +34,18 @@ def load_step(step_filename):
     reader.ReadFile(step_filename_str)
     reader.TransferRoots()
     shape = reader.OneShape()
-    exp = TopologyUtils.TopologyExplorer(shape, True)
-    bodies = []
-    for body in exp.solids():
-        bodies.append(Solid(body))
-    return bodies
+
+def load_step(step_filename):
+    """Load solids from a STEP file
+
+    Args:
+        step_filename (str): Path to STEP file
+
+    Returns:
+        List of occwl.Solid: a list of solid models from the file
+    """
+    compound = load_single_compound_from_step(step_filename)
+    return list(compound.solids())
 
 
 def save_step(list_of_solids, filename):

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -6,6 +6,7 @@ from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeVertex
 from OCC.Core.BRepExtrema import BRepExtrema_DistShapeShape
 from OCC.Core.Extrema import Extrema_ExtFlag_MIN
 from OCC.Core.gp import gp_Ax1
+from OCC.Core.TopAbs import TopAbs_REVERSED
 from OCC.Core.TopoDS import (
     TopoDS_Edge,
     TopoDS_Face,
@@ -13,6 +14,8 @@ from OCC.Core.TopoDS import (
     TopoDS_Solid,
     TopoDS_Vertex,
     TopoDS_Wire,
+    TopoDS_Compound,
+    TopoDS_CompSolid,
 )
 from OCC.Extend.ShapeFactory import (
     rotate_shape,
@@ -64,6 +67,8 @@ class Shape:
                 TopoDS_Wire,
                 TopoDS_Shell,
                 TopoDS_Solid,
+                TopoDS_Compound,
+                TopoDS_CompSolid,
             ),
         )
         self._shape = topods_shape

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -101,6 +101,22 @@ class Shape:
         """
         return self.topods_shape().__hash__() == other.topods_shape().__hash__()
 
+
+    def reversed(self):
+        """
+        Whether this shape is reversed.
+        
+        - For an edge this is whether the edge is reversed with respect to the curve geometry
+        - For a face this is whether the face is reversed with respect to the surface geometry
+        - For a vertex this is whether the vertex is at the upper or lower parameter value on the
+          edges curve
+
+        Returns:
+            bool: If rational
+        """
+        return self.topods_shape().Orientation() == TopAbs_REVERSED
+
+
     def find_closest_point_data(self, datum):
         """
         Find the information about the closest point on this shape

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -50,8 +50,11 @@ class Solid(Shape):
     A solid model
     """
 
-    def __init__(self, shape):
-        assert isinstance(shape, TopoDS_Solid)
+    def __init__(self, shape, allow_compound=False):
+        if allow_compound:
+            assert isinstance(shape, TopoDS_Compound) or isinstance(shape, TopoDS_CompSolid)
+        else:
+            assert isinstance(shape, TopoDS_Solid)
         super().__init__(shape)
         self._top_exp = TopologyUtils.TopologyExplorer(self.topods_shape(), True)
 

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -52,7 +52,9 @@ class Solid(Shape):
 
     def __init__(self, shape, allow_compound=False):
         if allow_compound:
-            assert isinstance(shape, TopoDS_Compound) or isinstance(shape, TopoDS_CompSolid)
+            assert (isinstance(shape, TopoDS_Solid) or 
+                isinstance(shape, TopoDS_Compound) or 
+                isinstance(shape, TopoDS_CompSolid))
         else:
             assert isinstance(shape, TopoDS_Solid)
         super().__init__(shape)

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -1,0 +1,16 @@
+from occwl.compound import Compound
+
+# Test
+from tests.test_base import TestBase
+
+
+class CompoundTester(TestBase):
+    def test_compound(self):
+        data_folder = self.test_folder() / "test_data"
+        compound_file = data_folder / "ManyBodies.stp"
+
+        compound = load_single_compound_from_step(compound_file)
+        num_solids = 0
+        solids = list(compound.solids())
+        self.assertEqual(len(solids), 2)
+        

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -1,4 +1,5 @@
 from occwl.compound import Compound
+from occwl.io import load_single_compound_from_step
 
 # Test
 from tests.test_base import TestBase
@@ -12,5 +13,13 @@ class CompoundTester(TestBase):
         compound = load_single_compound_from_step(compound_file)
         num_solids = 0
         solids = list(compound.solids())
-        self.assertEqual(len(solids), 2)
+
+        # We have 4 bodies.  Two are single shell solids
+        # and two have internal voids
+        #12=ADVANCED_BREP_SHAPE_REPRESENTATION('',(#435,#436,#13,#14),#704);
+        #13=MANIFOLD_SOLID_BREP('',#433);
+        #14=MANIFOLD_SOLID_BREP('',#434);
+        #435=BREP_WITH_VOIDS('',#429,(#25));
+        #436=BREP_WITH_VOIDS('',#431,(#26));
+        self.assertEqual(len(solids), 4)
         

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from occwl.vertex import Vertex
 
 # Test

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -1,0 +1,20 @@
+from occwl.vertex import Vertex
+
+# Test
+from tests.test_base import TestBase
+
+
+class VertexTester(TestBase):
+    def test_vertex(self):
+        data_folder = self.test_folder() / "test_data"
+        self.run_test_on_all_files_in_folder(data_folder)
+
+    def perform_tests_on_vertex(self, vertex):
+        reversed = vertex.reversed()
+        self.assertTrue(isinstance(reversed, bool))
+        pt = vertex.point()
+        self.assertTrue(isinstance(pt, np.ndarray))
+
+    def run_test(self, solid):
+        for vertex in solid.vertices():
+            self.perform_tests_on_vertex(vertex)


### PR DESCRIPTION
# Why?
Some STEP files contain multiple solids.  For example the [Fusion Gallery Reconstruction Dataset](https://github.com/AutodeskAILab/Fusion360GalleryDataset/blob/master/docs/reconstruction.md) has multiple solids generated by the construction sequences.   In some cases we want to process all these solids as if the disjoint solids regions were actually a single disjoint solid.  We can do this using a `Compound` or `CompSolid` in Open Cascade.

# What?

- Add a new class [Compound](src/occwl/compound.py) which derives from `Solid`.  All the usual methods for accessing data continue to work as normal.   One extra method is provided to split the `Compound` into solids.
- In [io](src/occwl/io.py) add a new method ` load_single_compound_from_step()` which loads all the file as a single STEP file.  The BRepNet pipeline was actually doing this with low level OCC functions.
- I also moved the `reversed()` functions from `Face` and `Edge` into `Shape`.  This allows access to `Vertex.reversed()`

# Verification
- Added new unit tests for `Vertex` and `Compound`
- All unit tests ran and passed
- Built a conda package and run the BRepNet extraction pipeline without errors 

