### PR TITLE
solid convert added to viewer.

### DIFF
--- a/src/occwl/viewer.py
+++ b/src/occwl/viewer.py
@@ -251,6 +251,8 @@ class Viewer:
                 shapes[i] = Edge(shapes[i])
             elif type(shapes[i]) == TopoDS_Face:
                 shapes[i] = Face(shapes[i])
+            elif type(shapes[i]) == TopoDS_Solid:
+                shapes[i] = Solid(shapes[i])
         return shapes
 
     def selected_shapes(self):


### PR DESCRIPTION
Select handler on solid selection returns object of type TopoDS_Solid. This is because 

``` _convert_to_occwl_types(*)``` does not check for solid type to convert to correct occwl::Solid type. 

Simple fix to remedy. 

Tests all pass. 