### PR TITLE
Update the occwl version to 0.0.3.   Remove deprecated functions

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "occwl" %}
-{% set version = "0.0.2" %}
+{% set version = "0.0.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="occwl",  # package name
-    version="0.0.2",
+    version="0.0.3",
     author="Pradeep Kumar Jayaraman, Joseph G. Lambourne",
     author_email="pradeep.kumar.jayaraman@autodesk.com, joseph.lambourne@autodesk.com",
     description="Lightweight Pythonic wrapper around pythonocc",
-    url="git.autodesk.com/Research/occwl",
+    url="https://github.com/AutodeskAILab/occwl",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",

--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -122,18 +122,6 @@ class Edge(Shape):
             return None
         return Edge(edge_builder.Edge())
 
-    @deprecated(
-        target=None, deprecated_in="0.01", remove_in="0.03", stream=logging.warning
-    )
-    def topods_edge(self):
-        """
-        Get the underlying OCC type
-
-        Returns:
-            OCC.Core.TopoDS.TopoDS_Edge: Edge
-        """
-        return self.topods_shape()
-
     def point(self, u):
         """
         Evaluate the edge geometry at given parameter

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -484,18 +484,6 @@ class Face(Shape):
             return "other"
         return "unknown"
 
-    @deprecated(
-        target=None, deprecated_in="0.01", remove_in="0.03", stream=logging.warning
-    )
-    def topods_face(self):
-        """
-        Get the underlying OCC type
-
-        Returns:
-            OCC.Core.TopoDS.TopoDS_Face: Face
-        """
-        return self.topods_shape()
-
     def closed_u(self):
         """
         Whether the surface is closed along the U-direction

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -122,18 +122,6 @@ class Solid(Shape):
             ).Shape()
         )
 
-    @deprecated(
-        target=None, deprecated_in="0.01", remove_in="0.03", stream=logging.warning
-    )
-    def topods_solid(self):
-        """
-        Get the underlying OCC type
-
-        Returns:
-            OCC.Core.TopoDS.TopoDS_Solid: Solid
-        """
-        return self.topods_shape()
-
     def vertices(self):
         """
         Get an iterator to go over all vertices in the solid

--- a/src/occwl/vertex.py
+++ b/src/occwl/vertex.py
@@ -51,14 +51,4 @@ class Vertex(Shape):
         pt = BRep_Tool.Pnt(self.topods_shape())
         return geom_utils.gp_to_numpy(pt)
 
-    @deprecated(
-        target=None, deprecated_in="0.01", remove_in="0.03", stream=logging.warning
-    )
-    def topods_vertex(self):
-        """
-        Get the underlying OCC type
 
-        Returns:
-            OCC.Core.TopoDS.TopoDS_Vertex: Vertex
-        """
-        return self.topods_shape()

--- a/src/occwl/wire.py
+++ b/src/occwl/wire.py
@@ -45,18 +45,6 @@ class Wire(Shape):
             return None
         return Wire(wire_builder.Wire())
 
-    @deprecated(
-        target=None, deprecated_in="0.01", remove_in="0.03", stream=logging.warning
-    )
-    def topods_wire(self):
-        """
-        Get the underlying OCC wire type
-
-        Returns:
-            OCC.Core.TopoDS.TopoDS_Wire: Wire
-        """
-        return self.topods_shape()
-
     def ordered_edges(self):
         """
         Get an iterator to go over the edges while respecting the wire ordering

--- a/tests/test_entity_mapper.py
+++ b/tests/test_entity_mapper.py
@@ -23,7 +23,7 @@ class EntityMapperTester(TestBase):
         self.run_test_on_all_files_in_folder(data_folder)
 
     def check_face_order(self, entity_mapper, solid):
-        top_exp = TopologyExplorer(solid.topods_solid())
+        top_exp = TopologyExplorer(solid.topods_shape())
         faces = top_exp.faces()
         for index, face in enumerate(faces):
             f = Face(face)
@@ -31,7 +31,7 @@ class EntityMapperTester(TestBase):
             self.assertEqual(mapped_index, index)
 
     def check_wire_order(self, entity_mapper, solid):
-        top_exp = TopologyExplorer(solid.topods_solid(), ignore_orientation=False)
+        top_exp = TopologyExplorer(solid.topods_shape(), ignore_orientation=False)
         wires = top_exp.wires()
         for index, wire in enumerate(wires):
             w = Wire(wire)
@@ -39,7 +39,7 @@ class EntityMapperTester(TestBase):
             self.assertEqual(mapped_index, index)
 
     def check_edge_order(self, entity_mapper, solid):
-        top_exp = TopologyExplorer(solid.topods_solid())
+        top_exp = TopologyExplorer(solid.topods_shape())
         edges = top_exp.edges()
         for index, edge in enumerate(edges):
             e = Edge(edge)
@@ -48,7 +48,7 @@ class EntityMapperTester(TestBase):
 
     def check_oriented_edge_order(self, entity_mapper, solid):
         oriented_top_exp = TopologyExplorer(
-            solid.topods_solid(), ignore_orientation=False
+            solid.topods_shape(), ignore_orientation=False
         )
         index = 0
         for wire in oriented_top_exp.wires():
@@ -60,7 +60,7 @@ class EntityMapperTester(TestBase):
                 index += 1
 
     def check_vertex_order(self, entity_mapper, solid):
-        top_exp = TopologyExplorer(solid.topods_solid())
+        top_exp = TopologyExplorer(solid.topods_shape())
         vertices = top_exp.vertices()
         for index, vertex in enumerate(vertices):
             v = Vertex(vertex)


### PR DESCRIPTION
# Why?
Some critical bug fixes need to be released under a new version number.  These include support for compound solids (PR#3) and support for multi-body assemblies with non-identity transforms (PR#6)

# What?

- Update the version number to 0.0.3
- Remove all the deprecated function
- Fix the unit tests

# Verification

- Built a conda package and all the unit tests pass when the package is run
- Testing the BRepNet pipeline now