### PR TITLE
Make Compound a standalone class

### DIFF
--- a/examples/ex2_load_and_display_step.py
+++ b/examples/ex2_load_and_display_step.py
@@ -1,11 +1,12 @@
 import pathlib
 
-from occwl.io import load_step
+from occwl.compound import Compound
 from occwl.viewer import Viewer
 
 
 # Returns a list of bodies from the step file, we only need the first one
-solid = load_step(pathlib.Path(__file__).resolve().parent.joinpath("example.stp"))[0]
+compound = Compound.load_from_step(pathlib.Path(__file__).resolve().parent.joinpath("example.stp"))
+solid = next(compound.solids())
 
 v = Viewer(backend="wx")
 v.display(solid)

--- a/examples/ex5_viewer_selection_screenshot.py
+++ b/examples/ex5_viewer_selection_screenshot.py
@@ -4,7 +4,7 @@ from occwl.face import Face
 from occwl.solid import Solid
 from occwl.vertex import Vertex
 from occwl.viewer import Viewer
-from occwl.io import load_step
+from occwl.compound import Compound
 
 v = Viewer(backend="wx")
 
@@ -39,7 +39,8 @@ v.add_menu("screenshot")
 v.add_submenu("screenshot", dump)
 
 # Display a solid
-solid = load_step(pathlib.Path(__file__).resolve().parent.joinpath("example.stp"))[0]
+compound = Compound.load_from_step(pathlib.Path(__file__).resolve().parent.joinpath("example.stp"))
+solid = next(compound.solids())
 v.display(solid, transparency=0.5)
 # Set the selection mode to face
 v.selection_mode_face()

--- a/examples/ex6_uvgrid_faceadj_graph.py
+++ b/examples/ex6_uvgrid_faceadj_graph.py
@@ -1,7 +1,6 @@
 import pathlib
 import numpy as np
 from occwl.graph import face_adjacency
-from occwl.io import load_step
 from occwl.solid import Solid
 from occwl.edge import Edge
 from occwl.uvgrid import uvgrid
@@ -10,7 +9,8 @@ from occwl.viewer import Viewer
 # example = Solid.make_box(10, 10, 10)
 # example = Solid.make_sphere(10, (0, 0, 0))
 example = Solid.make_cylinder(5, 10)
-# example = load_step(pathlib.Path(__file__).resolve().parent.joinpath("example.stp"))[0]
+# compound = Compound.load_from_step(pathlib.Path(__file__).resolve().parent.joinpath("example.stp"))
+# example = next(compound.solids())
 g = face_adjacency(example, self_loops=True)
 assert g is not None
 

--- a/examples/ex7_jupyter_viewer_example.ipynb
+++ b/examples/ex7_jupyter_viewer_example.ipynb
@@ -25,7 +25,7 @@
     "os.chdir(\"../src\")\n",
     "\n",
     "# Imports from occwl\n",
-    "from occwl.io import load_step\n",
+    "from occwl.compound import Compound\n",
     "from occwl.entity_mapper import EntityMapper\n",
     "from occwl.uvgrid import uvgrid\n",
     "from occwl.jupyter_viewer import JupyterViewer\n",
@@ -58,7 +58,7 @@
     }
    ],
    "source": [
-    "solids = load_step(\"examples/example.stp\")\n",
+    "solids = list(Compound.load_from_step(\"examples/example.stp\").solids())\n",
     "print(f\"Loaded {len(solids)} solids\")\n",
     "solid = solids[0]"
    ]
@@ -219,7 +219,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAAAfCAYAAABEbx5kAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAACSUlEQVR4nO3cu27cQAyF4TOyVr5ULpI6fro8bfIQqZM6tnUbFwayHO7MQHYMpsj/VZIORVFegIWx2JRzFgAgxvCvBwCA/wlLFwACsXQBIBBLFwACsXQBIBBLFwACjb3wLn3K93qQJOVUZtmsa5tlt8Zb2eG6VH6l7X09fF2uZr7fbs9N3e5mKrLO7LYuFcdlXfrLOl/b7XHgnl7doPY7XmTG4P82jXuK55rMjeeygz0uRq/36Nblzkz5WN1gv7Zpjgf/dU5zOjR6+3kvs8Z9/uOw2V6f7+LcRrura/XovGP3uXtrPrXrPrqHf0dz+l36lXP+rIru0r3Xg77qmyRpPZUPmG/Px+tkrt+VPYrsNr+5bp3az7V1fsayR/ms+WY399Svv56bHrb3jX/u+b752tRdl/228ZydTDaOZb9pstlevS5Jk3nueOV6nLZqZq9L0mT6j4N51ljWjYPpcbVVjyVpTKbHsFWv97Ipuflk6syxvf6amR5ayx7Z9Mimbi/rWtmY3UybmWMzdburW222V69L0rSYOtt7cfM1sml2det2LHte/hyntfx8ZDI9mx5L+Y56WurZ0/q+utlkj417fPZoesydOp/9Xt5eV8zXnj1JP9TAvxcAIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIFDK/od9bZjST3V+FxIAUPWl9SPm3aULAPhY/HsBAAKxdAEgEEsXAAKxdAEgEEsXAAK9AFeNKQkvQhLUAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAAAfCAYAAABEbx5kAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAACSUlEQVR4nO3cu27cQAyF4TOyVr5ULpI6fro8bfIQqZM6tnUbFwayHO7MQHYMpsj/VZIORVFegIWx2JRzFgAgxvCvBwCA/wlLFwACsXQBIBBLFwACsXQBIBBLFwACjb3wLn3K93qQJOVUZtmsa5tlt8Zb2eG6VH6l7X09fF2uZr7fbs9N3e5mKrLO7LYuFcdlXfrLOl/b7XHgnl7doPY7XmTG4P82jXuK55rMjeeygz0uRq/36Nblzkz5WN1gv7Zpjgf/dU5zOjR6+3kvs8Z9/uOw2V6f7+LcRrura/XovGP3uXtrPrXrPrqHf0dz+l36lXP+rIru0r3Xg77qmyRpPZUPmG/Px+tkrt+VPYrsNr+5bp3az7V1fsayR/ms+WY399Svv56bHrb3jX/u+b752tRdl/228ZydTDaOZb9pstlevS5Jk3nueOV6nLZqZq9L0mT6j4N51ljWjYPpcbVVjyVpTKbHsFWv97Ipuflk6syxvf6amR5ayx7Z9Mimbi/rWtmY3UybmWMzdburW222V69L0rSYOtt7cfM1sml2det2LHte/hyntfx8ZDI9mx5L+Y56WurZ0/q+utlkj417fPZoesydOp/9Xt5eV8zXnj1JP9TAvxcAIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIBBLFwACsXQBIFDK/od9bZjST3V+FxIAUPWl9SPm3aULAPhY/HsBAAKxdAEgEEsXAAKxdAEgEEsXAAK9AFeNKQkvQhLUAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]

--- a/src/occwl/compound.py
+++ b/src/occwl/compound.py
@@ -1,32 +1,127 @@
-from OCC.Core.TopoDS import (
-    topods,
-    TopoDS_Wire,
-    TopoDS_Vertex,
-    TopoDS_Edge,
-    TopoDS_Face,
-    TopoDS_Shell,
-    TopoDS_Solid,
-    TopoDS_Shape,
-    TopoDS_Compound,
-    TopoDS_CompSolid,
-    topods_Edge,
-    topods_Vertex,
-    TopoDS_Iterator,
-)
-
+from OCC.Core.TopoDS import TopoDS_Compound, TopoDS_CompSolid
+from OCC.Extend.DataExchange import read_step_file, list_of_shapes_to_compound
+from occwl.shape import Shape
 from occwl.solid import Solid
+from occwl.face import Face
+from occwl.wire import Wire
+from occwl.edge import Edge
+from occwl.vertex import Vertex
 
 
-class Compound(Solid):
+class Compound(Shape):
     """
-    A compound which can be worked with as many solids
+    A compound which can be worked with as many shapes
     lumped together.
     """
     def __init__(self, shape):
-        assert (isinstance(shape, TopoDS_Solid) or 
-                isinstance(shape, TopoDS_Compound) or 
-                isinstance(shape, TopoDS_CompSolid))
-        super().__init__(shape, allow_compound=True)
-        
+        assert isinstance(shape, TopoDS_Compound)
+        super().__init__(shape)
+    
+    @staticmethod
+    def load_from_step(filename, verbosity=False):
+        """
+        Load everything from a STEP file as a single Compound
+
+        Args:
+            filename (str or pathlib.Path): STEP filename
+            verbosity (bool): Whether to print detailed information while loading
+
+        Returns:
+            occwl.compound.Compound: Compound shape
+        """
+        shp = read_step_file(str(filename), as_compound=True, verbosity=False)
+        if not isinstance(shp, TopoDS_Compound):
+            shp, success = list_of_shapes_to_compound([shp])
+            assert success
+        return Compound(shp)
+
+    def num_solids(self):
+        """
+        Number of solids in the Compound
+
+        Returns:
+            int: Number of faces
+        """
+        return self._top_exp.number_of_solids()
+
+    def num_faces(self):
+        """
+        Number of faces in the Compound
+
+        Returns:
+            int: Number of faces
+        """
+        return self._top_exp.number_of_faces()
+
+    def num_wires(self):
+        """
+        Number of wires in the Compound
+
+        Returns:
+            int: Number of wires
+        """
+        return self._top_exp.number_of_wires()
+
+    def num_edges(self):
+        """
+        Number of edges in the Compound
+
+        Returns:
+            int: Number of edges
+        """
+        return self._top_exp.number_of_edges()
+
+    def num_vertices(self):
+        """
+        Number of vertices in the Compound
+
+        Returns:
+            int: Number of vertices
+        """
+        return self._top_exp.number_of_vertices()
+
+    def vertices(self):
+        """
+        Get an iterator to go over all vertices in the Compound
+
+        Returns:
+            Iterator[occwl.vertex.Vertex]: Vertex iterator
+        """
+        return map(Vertex, self._top_exp.vertices())
+
+    def edges(self):
+        """
+        Get an iterator to go over all edges in the Compound
+
+        Returns:
+            Iterator[occwl.edge.Edge]: Edge iterator
+        """
+        return map(Edge, self._top_exp.edges())
+
+    def faces(self):
+        """
+        Get an iterator to go over all faces in the Compound
+
+        Returns:
+            Iterator[occwl.face.Face]: Face iterator
+        """
+        return map(Face, self._top_exp.faces())
+
+    def wires(self):
+        """
+        Get an iterator to go over all wires in the Compound
+
+        Returns:
+            Iterator[occwl.wire.Wire]: Wire iterator
+        """
+        return map(Wire, self._top_exp.wires())
+
     def solids(self):
+        """
+        Get an iterator to go over all solids in the Compound
+
+        Returns:
+            Iterator[occwl.solid.Solid]: Solid iterator
+        """
         return map(Solid, self._top_exp.solids())
+    

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -13,6 +13,7 @@ from OCC.Core.IFSelect import IFSelect_RetDone
 
 from pathlib import Path
 
+
 def load_single_compound_from_step(step_filename):
     """
     Load data from a STEP file as a single compound
@@ -24,17 +25,7 @@ def load_single_compound_from_step(step_filename):
         List of occwl.Compound: a single compound containing all shapes in
                                 the file
     """
-    # Check that the file exists.  OCC can crash if the file isn't there
-    step_filename_path = Path(step_filename)
-    if not step_filename_path.exists():
-        return []
-
-    step_filename_str = str(step_filename)
-    reader = STEPControl_Reader()
-    reader.ReadFile(step_filename_str)
-    reader.TransferRoots()
-    shape = reader.OneShape()
-    return Compound(shape)
+    return Compound.load_from_step(step_filename)
 
 def load_step(step_filename):
     """Load solids from a STEP file

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -1,19 +1,13 @@
-from OCC.Core.STEPControl import STEPControl_Reader
 from occwl.compound import Compound
 from occwl.solid import Solid
 from occwl.face import Face
 from occwl.edge import Edge
-from occwl.geometry import geom_utils
 from OCC.Extend.DataExchange import export_shape_to_svg
-from OCC.Extend import TopologyUtils
 from OCC.Core.gp import gp_Pnt, gp_Dir
-from OCC.Core.STEPControl import STEPControl_Writer, STEPControl_AsIs
-from OCC.Core.Interface import Interface_Static_SetCVal
-from OCC.Core.IFSelect import IFSelect_RetDone
-
-from pathlib import Path
+from deprecate import deprecated
 
 
+@deprecated(target=None, deprecated_in="0.0.3", remove_in="0.0.5")
 def load_single_compound_from_step(step_filename):
     """
     Load data from a STEP file as a single compound
@@ -27,6 +21,8 @@ def load_single_compound_from_step(step_filename):
     """
     return Compound.load_from_step(step_filename)
 
+
+@deprecated(target=None, deprecated_in="0.0.3", remove_in="0.0.5")
 def load_step(step_filename):
     """Load solids from a STEP file
 

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -24,7 +24,7 @@ from OCC.Extend.ShapeFactory import (
     translate_shp,
 )
 from OCC.Core.BRepCheck import BRepCheck_Analyzer 
-
+from OCC.Extend import TopologyUtils
 import occwl.geometry.geom_utils as geom_utils
 
 
@@ -72,6 +72,7 @@ class Shape:
             ),
         )
         self._shape = topods_shape
+        self._top_exp = TopologyUtils.TopologyExplorer(self.topods_shape(), True)
 
     def topods_shape(self):
         """

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -58,7 +58,6 @@ class Solid(Shape):
         else:
             assert isinstance(shape, TopoDS_Solid)
         super().__init__(shape)
-        self._top_exp = TopologyUtils.TopologyExplorer(self.topods_shape(), True)
 
     @staticmethod
     def make_box(width, height, depth):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 
 # OCC
-from occwl.io import load_step
+from occwl.compound import Compound
 
 
 class TestBase(unittest.TestCase):
@@ -16,7 +16,8 @@ class TestBase(unittest.TestCase):
     def load_single_solid_from_test_data(self, filename):
         solid_pathname = self.test_folder() / "test_data" / filename
         self.assertTrue(solid_pathname.exists())
-        solids = load_step(solid_pathname)
+        comp = Compound.load_from_step(solid_pathname)
+        solids = list(comp.solids())
         self.assertEqual(len(solids), 1)
         return solids[0]
 
@@ -30,7 +31,7 @@ class TestBase(unittest.TestCase):
 
         for file in step_files:
             print(f"Running tests for {file.stem}{file.suffix}")
-            solids = load_step(file)
+            solids = list(Compound.load_from_step(file).solids())
             for solid in solids:
                 self.run_test_with_pathname(file, solid)
 

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -10,8 +10,8 @@ class CompoundTester(TestBase):
         data_folder = self.test_folder() / "test_data"
         compound_file = data_folder / "ManyBodies.stp"
 
-        compound = load_single_compound_from_step(compound_file)
-        num_solids = 0
+        compound = Compound.load_from_step(compound_file)
+        num_solids = compound.num_solids()
         solids = list(compound.solids())
 
         # We have 4 bodies.  Two are single shell solids
@@ -22,4 +22,4 @@ class CompoundTester(TestBase):
         #435=BREP_WITH_VOIDS('',#429,(#25));
         #436=BREP_WITH_VOIDS('',#431,(#26));
         self.assertEqual(len(solids), 4)
-        
+        self.assertEqual(num_solids, 4)

--- a/tests/test_edge_data_extractor.py
+++ b/tests/test_edge_data_extractor.py
@@ -19,7 +19,7 @@ from OCC.Core.Quantity import (
 
 # occwl
 from occwl.edge_data_extractor import EdgeDataExtractor, EdgeConvexity
-from occwl.io import load_step
+from occwl.compound import Compound
 from occwl.viewer import Viewer
 
 # Test
@@ -31,7 +31,7 @@ class EdgeDataExtractorTester(TestBase):
         # Load the solid
         solid_pathname = self.test_folder() / "test_data" / filename
         self.assertTrue(solid_pathname.exists())
-        solids = load_step(solid_pathname)
+        solids = list(Compound.load_from_step(solid_pathname).solids())
         self.assertEqual(len(solids), 1)
         solid = solids[0]
 


### PR DESCRIPTION
`Compound` is now a separate class derived from `Shape` and acts as a container for all kinds of topological entities. It supports:

- A unified way to load everything from a STEP file as a `Compound` object using `Compound.load_from_step()`. The previous way to load a single solid (`io.load_from_step()`) or a list of solids (`io.load_single_compound_from_step`) is deprecated in favor of this method that is more general.
- Methods to iterate over all topological entities, e.g., `Compound.solids()`, `Compound.edges()` etc.

Other minor changes:
- The topology explorer in `Solid` is moved to the base `Shape` class.