### PR TITLE
uv_grid mask

### DIFF
--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -21,7 +21,7 @@ from OCC.Core.GeomLProp import GeomLProp_SLProps
 from OCC.Core.gp import gp_Dir, gp_Pnt, gp_Pnt2d, gp_TrsfForm
 from OCC.Core.GProp import GProp_GProps
 from OCC.Core.ShapeAnalysis import ShapeAnalysis_Surface
-from OCC.Core.TopAbs import TopAbs_IN, TopAbs_REVERSED, TopAbs_ON
+from OCC.Core.TopAbs import TopAbs_IN, TopAbs_REVERSED
 from OCC.Core.TopLoc import TopLoc_Location
 from OCC.Core.TopoDS import TopoDS_Face
 from OCC.Extend import TopologyUtils
@@ -188,7 +188,7 @@ class Face(Shape):
             bool: Is inside
         """
         result = self._trimmed.Perform(gp_Pnt2d(uv[0], uv[1]))
-        return result == TopAbs_IN or result == TopAbs_ON
+        return result == TopAbs_IN
     
     def visibility_status(self, uv):
         """

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -179,7 +179,7 @@ class Face(Shape):
 
     def inside(self, uv):
         """
-        Check if the uv-coordinate in on the visible region of the face
+        Check if the uv-coordinate is inside the visible region of the face (excludes points that lie on the boundary)
 
         Args:
             uv (np.ndarray or tuple): Surface parameter

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -21,7 +21,7 @@ from OCC.Core.GeomLProp import GeomLProp_SLProps
 from OCC.Core.gp import gp_Dir, gp_Pnt, gp_Pnt2d, gp_TrsfForm
 from OCC.Core.GProp import GProp_GProps
 from OCC.Core.ShapeAnalysis import ShapeAnalysis_Surface
-from OCC.Core.TopAbs import TopAbs_IN, TopAbs_REVERSED
+from OCC.Core.TopAbs import TopAbs_IN, TopAbs_REVERSED, TopAbs_ON
 from OCC.Core.TopLoc import TopLoc_Location
 from OCC.Core.TopoDS import TopoDS_Face
 from OCC.Extend import TopologyUtils
@@ -188,7 +188,7 @@ class Face(Shape):
             bool: Is inside
         """
         result = self._trimmed.Perform(gp_Pnt2d(uv[0], uv[1]))
-        return result == TopAbs_IN
+        return result == TopAbs_IN or result == TopAbs_ON
     
     def visibility_status(self, uv):
         """


### PR DESCRIPTION
### What

Include points that lie on the trimming loop within the uvgrid mask as 1 instead of 0.

### Why

Current behaviour is to exclude points that lie on trimming loop from the mask (BLUE = TRUE, RED = FALSE):

![Screenshot 2022-01-12 at 11 29 15](https://user-images.githubusercontent.com/23616959/149132143-2391413c-50ec-41a1-83a6-392c922a3a79.png)

Whereas the previous pipeline for these features using ASM did the following:

![Screenshot 2022-01-12 at 11 30 12](https://user-images.githubusercontent.com/23616959/149132264-9ab80a83-dcb8-45dc-8997-9c56bc68eb3a.png)

### Verification

All tests passing and I have checked the masks on several solids.