### PR TITLE
Offscreen renderer

### DIFF
--- a/examples/ex7_offscreen_rendering.py
+++ b/examples/ex7_offscreen_rendering.py
@@ -1,0 +1,9 @@
+from occwl.solid import Solid
+from occwl.viewer import OffscreenRenderer
+
+
+v = OffscreenRenderer()
+ex = Solid.make_box(1, 2, 1)
+v.display(ex)
+v.fit()
+v.save_image("image.png")

--- a/src/occwl/viewer.py
+++ b/src/occwl/viewer.py
@@ -14,6 +14,11 @@ from OCC.Core.Aspect import (
     Aspect_TOM_STAR,
     Aspect_TOM_X,
 )
+from OCC.Core.Graphic3d import (
+    Graphic3d_TOSM_VERTEX,
+    Graphic3d_TOSM_FACET,
+    Graphic3d_TOSM_FRAGMENT
+)
 from OCC.Core.gp import gp_Ax1
 from OCC.Core.Geom import Geom_CartesianPoint, Geom_Line
 from OCC.Core.Prs3d import Prs3d_LineAspect, Prs3d_PointAspect
@@ -342,6 +347,24 @@ class _BaseViewer:
             tuple_of_width_and_height (Tuple[int, int]): Width and height
         """
         self._display.SetSize(tuple_of_width_and_height)
+    
+    def use_gouraud_shading(self):
+        """
+        Compute colors per vertex and interpolate
+        """
+        self.SetShadingModel(Graphic3d_TOSM_VERTEX)
+    
+    def use_flat_shading(self):
+        """
+        Use no interpolation when computing color for fragments in a triangle
+        """
+        self.SetShadingModel(Graphic3d_TOSM_FACET)
+
+    def use_phong_shading(self):
+        """
+        Compute colors per fragment
+        """
+        self.SetShadingModel(Graphic3d_TOSM_FRAGMENT)
 
 
 class Viewer(_BaseViewer):

--- a/src/occwl/viewer.py
+++ b/src/occwl/viewer.py
@@ -295,7 +295,7 @@ class _BaseViewer:
         """
         Show the XYZ-axes widget
         """
-        self._display.show_triedron()
+        self._display.display_triedron()
 
     def hide_axes(self):
         """
@@ -339,32 +339,33 @@ class _BaseViewer:
         """
         self._display.default_drawer.SetFaceBoundaryDraw(False)
     
-    def set_size(self, tuple_of_width_and_height):
+    def set_size(self, width, height):
         """
         Set the size of the framebuffer
 
         Args:
-            tuple_of_width_and_height (Tuple[int, int]): Width and height
+            width (int): Width of the framebuffer
+            height (int): Height of the framebuffer
         """
-        self._display.SetSize(tuple_of_width_and_height)
+        self._display.SetSize(width, height)
     
     def use_gouraud_shading(self):
         """
         Compute colors per vertex and interpolate
         """
-        self.SetShadingModel(Graphic3d_TOSM_VERTEX)
+        self._display.View.SetShadingModel(Graphic3d_TOSM_VERTEX)
     
     def use_flat_shading(self):
         """
         Use no interpolation when computing color for fragments in a triangle
         """
-        self.SetShadingModel(Graphic3d_TOSM_FACET)
+        self._display.View.SetShadingModel(Graphic3d_TOSM_FACET)
 
     def use_phong_shading(self):
         """
         Compute colors per fragment
         """
-        self.SetShadingModel(Graphic3d_TOSM_FRAGMENT)
+        self._display.View.SetShadingModel(Graphic3d_TOSM_FRAGMENT)
 
 
 class Viewer(_BaseViewer):
@@ -536,5 +537,6 @@ class OffscreenRenderer(_BaseViewer):
             self.show_axes()
         else:
             self.hide_axes()
-        self.set_size(size)
+        self.set_size(*size)
         self.set_background_color(background_top_color, background_bottom_color)
+        self.shaded()


### PR DESCRIPTION
Moved reusable functionalities from `Viewer`  to `_BaseViewer` and derived an `OffscreenRenderer` class that can be used for batch rendering. A small example has been added to `examples/ex7_offscreen_rendering.py`.

Additionally, exposed more functionalities in the viewer API for:
- Showing/hiding face boundaries
- Switching between Gouraud, Phong or flat shading
- Toggling antialiasing
- Showing/hiding the XYZ-axes widget