### PR TITLE
Shell class

### DIFF
--- a/src/occwl/base.py
+++ b/src/occwl/base.py
@@ -261,7 +261,7 @@ class FaceContainerMixin:
 
 class ShellContainerMixin:
     """
-    A mixin class that adds the ability to perform operations on the solids
+    A mixin class that adds the ability to perform operations on the shells
     in the shape
     """
     def num_shells(self):
@@ -271,7 +271,7 @@ class ShellContainerMixin:
         Returns:
             int: Number of shells
         """
-        return self._top_exp.number_of_solids()
+        return self._top_exp.number_of_shells()
 
     def shells(self):
         """

--- a/src/occwl/base.py
+++ b/src/occwl/base.py
@@ -259,6 +259,31 @@ class FaceContainerMixin:
         return type(self)(divider.Result())
 
 
+class ShellContainerMixin:
+    """
+    A mixin class that adds the ability to perform operations on the solids
+    in the shape
+    """
+    def num_shells(self):
+        """
+        Number of shells in the Shape
+
+        Returns:
+            int: Number of shells
+        """
+        return self._top_exp.number_of_solids()
+
+    def shells(self):
+        """
+        Get an iterator to go over all shells in the Shape
+
+        Returns:
+            Iterator[occwl.shell.Shell]: Shell iterator
+        """
+        from occwl.shell import Shell
+        return map(Shell, self._top_exp.shells())
+
+
 class SolidContainerMixin:
     """
     A mixin class that adds the ability to perform operations on the solids
@@ -269,7 +294,7 @@ class SolidContainerMixin:
         Number of solids in the Compound
 
         Returns:
-            int: Number of faces
+            int: Number of solids
         """
         return self._top_exp.number_of_solids()
 

--- a/src/occwl/compound.py
+++ b/src/occwl/compound.py
@@ -1,12 +1,12 @@
 from OCC.Core.TopoDS import TopoDS_Compound
 from OCC.Extend.DataExchange import read_step_file, list_of_shapes_to_compound
-from occwl.base import BottomUpFaceIterator, BoundingBoxMixin, \
+from occwl.base import BottomUpFaceIterator, BottomUpEdgeIterator, BoundingBoxMixin, \
     EdgeContainerMixin, FaceContainerMixin, SolidContainerMixin, SurfacePropertiesMixin, \
         TriangulatorMixin, VertexContainerMixin, VolumePropertiesMixin, WireContainerMixin
 from occwl.shape import Shape
 
 
-class Compound(Shape, BottomUpFaceIterator, BoundingBoxMixin,
+class Compound(Shape, BottomUpFaceIterator, BoundingBoxMixin, BottomUpEdgeIterator,
     EdgeContainerMixin, FaceContainerMixin, SolidContainerMixin, SurfacePropertiesMixin,
     TriangulatorMixin, VertexContainerMixin, VolumePropertiesMixin, WireContainerMixin):
     """

--- a/src/occwl/compound.py
+++ b/src/occwl/compound.py
@@ -2,12 +2,13 @@ from OCC.Core.TopoDS import TopoDS_Compound
 from OCC.Extend.DataExchange import read_step_file, list_of_shapes_to_compound
 from occwl.base import BottomUpFaceIterator, BottomUpEdgeIterator, BoundingBoxMixin, \
     EdgeContainerMixin, FaceContainerMixin, SolidContainerMixin, SurfacePropertiesMixin, \
-        TriangulatorMixin, VertexContainerMixin, VolumePropertiesMixin, WireContainerMixin
+        TriangulatorMixin, VertexContainerMixin, VolumePropertiesMixin, WireContainerMixin, \
+            ShellContainerMixin
 from occwl.shape import Shape
 
 
 class Compound(Shape, BottomUpFaceIterator, BoundingBoxMixin, BottomUpEdgeIterator,
-    EdgeContainerMixin, FaceContainerMixin, SolidContainerMixin, SurfacePropertiesMixin,
+    EdgeContainerMixin, FaceContainerMixin, SolidContainerMixin, ShellContainerMixin, SurfacePropertiesMixin,
     TriangulatorMixin, VertexContainerMixin, VolumePropertiesMixin, WireContainerMixin):
     """
     A compound which can be worked with as many shapes

--- a/src/occwl/graph.py
+++ b/src/occwl/graph.py
@@ -3,6 +3,7 @@ from occwl.compound import Compound
 from occwl.solid import Solid
 from occwl.face import Face
 from occwl.wire import Wire
+from occwl.shell import Shell
 from occwl.entity_mapper import EntityMapper
 
 
@@ -11,7 +12,7 @@ def face_adjacency(shape, self_loops=False):
     Creates a face adjacency graph from the given shape (Solid or Compound)
 
     Args:
-        solid (Solid, or Compound): Shape
+        shape (Shell, Solid, or Compound): Shape
         self_loops (bool, optional): Whether to add self loops in the graph. Defaults to False.
         
     Returns:
@@ -23,8 +24,7 @@ def face_adjacency(shape, self_loops=False):
                     - "edge_idx": index of the (ordered) edge in the solid
         None: if the shape is non-manifold or open
     """
-    # TODO(pradeep): also allow Shell in future
-    assert isinstance(shape, (Solid, Compound))
+    assert isinstance(shape, (Shell, Solid, Compound))
     mapper = EntityMapper(shape)
     graph = nx.DiGraph()
     for face in shape.faces():
@@ -62,7 +62,7 @@ def vertex_adjacency(shape, self_loops=False):
     Creates a vertex adjacency graph from the given shape (Wire, Solid or Compound)
 
     Args:
-        shape (Wire, Face, Solid, or Compound): Shape
+        shape (Wire, Face, Shell, Solid, or Compound): Shape
         self_loops (bool, optional): Whether to add self loops in the graph. Defaults to False.
     
     Returns:
@@ -73,8 +73,7 @@ def vertex_adjacency(shape, self_loops=False):
                     - "edge": contains the B-rep (ordered) edge
                     - "edge_idx": index of the (ordered) edge in the solid
     """
-    # TODO(pradeep): also allow Shell in future
-    assert isinstance(shape, (Wire, Face, Solid, Compound))
+    assert isinstance(shape, (Wire, Face, Shell, Solid, Compound))
     mapper = EntityMapper(shape)
     graph = nx.DiGraph()
     for vert in shape.vertices():

--- a/src/occwl/shell.py
+++ b/src/occwl/shell.py
@@ -1,0 +1,39 @@
+from OCC.Core.TopoDS import TopoDS_Shell
+from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_Sewing
+from occwl.base import BottomUpEdgeIterator, BottomUpFaceIterator, BoundingBoxMixin, \
+    EdgeContainerMixin, FaceContainerMixin, SurfacePropertiesMixin, \
+        TriangulatorMixin, VertexContainerMixin, WireContainerMixin
+from occwl.shape import Shape
+from occwl.face import Face
+
+
+class Shell(BottomUpFaceIterator, BottomUpEdgeIterator,
+    BoundingBoxMixin,  VertexContainerMixin, EdgeContainerMixin, WireContainerMixin, FaceContainerMixin,
+    SurfacePropertiesMixin, TriangulatorMixin, Shape):
+    """
+    A shell is a sewed set of faces.
+    """
+    def __init__(self, shape):
+        assert isinstance(shape, TopoDS_Shell)
+        super().__init__(shape)
+
+    @staticmethod
+    def make_by_sewing_faces(faces):
+        """
+        Make a shell by sewing a set of faces with overlapping edges
+
+        Args:
+            faces (List[occwl.face.Face]): List of faces
+
+        Returns:
+            Shell or None: Sewed shell or None if the output was not a Shell
+        """
+        sew = BRepBuilderAPI_Sewing()
+        for f in faces:
+            assert isinstance(f, Face)
+            sew.Add(f.topods_face())
+        sew.Perform()
+        sewed_shape = sew.SewedShape()
+        if isinstance(sewed_shape, TopoDS_Shell):
+            return Shell(sewed_shape)
+        return None

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -9,7 +9,7 @@ from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Pnt2d, gp_Ax2
 import math
 from occwl.base import VertexContainerMixin, EdgeContainerMixin, \
             WireContainerMixin, FaceContainerMixin, BottomUpFaceIterator, \
-            SurfacePropertiesMixin, VolumePropertiesMixin, \
+            BottomUpEdgeIterator, SurfacePropertiesMixin, VolumePropertiesMixin, \
             BoundingBoxMixin, TriangulatorMixin
 
 from occwl.geometry import geom_utils
@@ -20,7 +20,7 @@ import logging
 
 class Solid(Shape, VertexContainerMixin, EdgeContainerMixin, \
             WireContainerMixin, FaceContainerMixin, BottomUpFaceIterator, \
-            SurfacePropertiesMixin, VolumePropertiesMixin, \
+            BottomUpEdgeIterator, SurfacePropertiesMixin, VolumePropertiesMixin, \
             BoundingBoxMixin, TriangulatorMixin):
     """
     A solid model

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -10,7 +10,7 @@ import math
 from occwl.base import VertexContainerMixin, EdgeContainerMixin, \
             WireContainerMixin, FaceContainerMixin, BottomUpFaceIterator, \
             BottomUpEdgeIterator, SurfacePropertiesMixin, VolumePropertiesMixin, \
-            BoundingBoxMixin, TriangulatorMixin
+            BoundingBoxMixin, TriangulatorMixin, ShellContainerMixin
 
 from occwl.geometry import geom_utils
 from occwl.shape import Shape
@@ -18,7 +18,7 @@ from deprecate import deprecated
 import logging
 
 
-class Solid(Shape, VertexContainerMixin, EdgeContainerMixin, \
+class Solid(Shape, VertexContainerMixin, EdgeContainerMixin, ShellContainerMixin, \
             WireContainerMixin, FaceContainerMixin, BottomUpFaceIterator, \
             BottomUpEdgeIterator, SurfacePropertiesMixin, VolumePropertiesMixin, \
             BoundingBoxMixin, TriangulatorMixin):

--- a/src/occwl/viewer.py
+++ b/src/occwl/viewer.py
@@ -31,6 +31,7 @@ from OCC.Core.TopoDS import (
     TopoDS_Shell,
     TopoDS_Solid,
     TopoDS_Vertex,
+    TopoDS_Compound,
 )
 from OCC.Display.SimpleGui import init_display
 from OCC.Display.OCCViewer import get_color_from_name
@@ -42,6 +43,7 @@ from occwl.geometry import geom_utils
 from occwl.solid import Solid
 from occwl.vertex import Vertex
 from occwl.compound import Compound
+from occwl.shell import Shell
 
 
 class Viewer:
@@ -92,7 +94,7 @@ class Viewer:
                                            'CYAN', 'BLACK', or 'ORANGE'. Defaults to None.
             transparency (float, optional): How transparent the shape is. Defaults to 0.0.
         """
-        if isinstance(shape, (Compound, Solid, Face, Edge, Wire, Vertex)):
+        if isinstance(shape, (Compound, Solid, Shell, Face, Edge, Wire, Vertex)):
             shape = shape.topods_shape()
         if color and not isinstance(color, (str, tuple)):
             color = "BLACK"
@@ -252,8 +254,12 @@ class Viewer:
                 shapes[i] = Edge(shapes[i])
             elif type(shapes[i]) == TopoDS_Face:
                 shapes[i] = Face(shapes[i])
+            elif type(shapes[i]) == TopoDS_Shell:
+                shapes[i] = Shell(shapes[i])
             elif type(shapes[i]) == TopoDS_Solid:
                 shapes[i] = Solid(shapes[i])
+            elif type(shapes[i]) == TopoDS_Compound:
+                shapes[i] = Compound(shapes[i])
         return shapes
 
     def selected_shapes(self):


### PR DESCRIPTION
This PR adds a `Shell` class and support for iterating over them in `Solid` and `Compound`.
`Shell` objects can be passed to `Viewer` for displaying.
`occwl.graph.face_adjacency` and `occwl.graph.vertex_adjacency` now accept `Shell`s.