### PR TITLE
Geometry type enums

### DIFF
--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -390,6 +390,15 @@ class Edge(Shape):
             return "other"
         return "unknown"
 
+    def curve_type_enum(self):
+        """
+        Get the type of the curve geometry as an OCC.Core.GeomAbs enum
+
+        Returns:
+            OCC.Core.GeomAbs: Type of the curve geometry
+        """
+        return BRepAdaptor_Curve(self.topods_shape()).GetType()
+
     def tolerance(self):
         """
         Get tolerance of this edge.  The 3d curve of the edge should not

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -483,6 +483,15 @@ class Face(Shape):
         if surf_type == GeomAbs_OtherSurface:
             return "other"
         return "unknown"
+    
+    def surface_type_enum(self):
+        """
+        Get the type of the surface geometry as an OCC.Core.GeomAbs enum
+
+        Returns:
+            OCC.Core.GeomAbs: Type of the surface geometry
+        """
+        return BRepAdaptor_Surface(self.topods_shape()).GetType()
 
     def closed_u(self):
         """

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -7,6 +7,7 @@ from OCC.Core.gp import gp_XOY, gp_Pnt
 from OCC.Core.GC import GC_MakeSegment
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 from OCC.Core.Geom import Geom_Circle
+from OCC.Core.GeomAbs import GeomAbs_Circle
 from occwl.edge import Edge
 
 # Test
@@ -89,8 +90,10 @@ class EdgeTester(TestBase):
         circle = BRepBuilderAPI_MakeEdge(Geom_Circle(gp_XOY(), 1)).Edge()
         circle = Edge(circle)
         curve_type = circle.curve_type()
+        curve_type_enum = circle.curve_type_enum()
         self.assertTrue(isinstance(curve_type, str))
         self.assertTrue(curve_type == "circle")
+        self.assertTrue(curve_type_enum == GeomAbs_Circle)
 
     def _test_specific_curve(self, edge):
         if edge.has_curve():


### PR DESCRIPTION
Add methods `Edge.curve_type_enum()` and `Face.surface_type_enum()` to obtain the curve and surface geometry types as `OCC.Core.GeomAbs` enums. Resolves #4 