### PR TITLE
Update to version 1.0.0.    Add code to apply an arbitrary transform

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "occwl" %}
-{% set version = "0.0.3" %}
+{% set version = "1.0.0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="occwl",  # package name
-    version="0.0.3",
+    version="1.0.0",
     author="Pradeep Kumar Jayaraman, Joseph G. Lambourne",
     author_email="pradeep.kumar.jayaraman@autodesk.com, joseph.lambourne@autodesk.com",
     description="Lightweight Pythonic wrapper around pythonocc",

--- a/src/occwl/base.py
+++ b/src/occwl/base.py
@@ -591,10 +591,42 @@ class BoundingBoxMixin:
         brepbndlib_AddOptimal(self.topods_shape(), b, use_triangulation, use_shapetolerance)
         return geom_utils.box_to_geometry(b)
 
-    def scale_to_box(self, box_side):
+
+    def transform(self, a, copy=True):
+        """
+        Apply the given 4x4 transform matrix to the solid
+
+        Args: a (nd.array) - Homogeneous transform matrix
+                             The transform that will be applied is
+                                        
+                             x' =  a[0,0]*x + a[0,1]*y + a[0,2]*z + a[0, 3]
+                             y' =  a[1,0]*x + a[1,1]*y + a[1,2]*z + a[1, 3]
+                             z' =  a[2,0]*x + a[2,1]*y + a[2,2]*z + a[2, 3]
+
+             copy (bool)    True - Copy entities and apply the transform to
+                                   the underlying geometry
+                            False - Apply the transform to the topods Locator
+                                    if possible 
+        """
+        trsf = gp_Trsf()
+        trsf.SetValues(
+            a[0,0], a[0,1], a[0,2], a[0, 3],
+            a[1,0], a[1,1], a[1,2], a[1, 3],
+            a[2,0], a[2,1], a[2,2], a[2, 3],
+        )
+        return self._apply_transform(trsf, copy=copy)
+
+    def scale_to_box(self, box_side, copy=True):
         """
         Translate and scale the Shape so it fits exactly 
         into the [-box_side, box_side]^3 box
+
+        Args:
+            box_side (float) The side length of the box
+            copy (bool)      True - Copy entities and apply the transform to
+                                    the underlying geometry
+                             False - Apply the transform to the topods Locator
+                                     if possible 
 
         Returns:
             occwl.*.*: The scaled version of this Shape
@@ -615,22 +647,34 @@ class BoundingBoxMixin:
         scale_trsf.SetScale(orig, (2.0 * box_side) / longest_length)
         trsf_to_apply = scale_trsf.Multiplied(move_to_center)
         
-        apply_transform = BRepBuilderAPI_Transform(trsf_to_apply)
-        apply_transform.Perform(self.topods_shape())
-        transformed_shape = apply_transform.ModifiedShape(self.topods_shape())
+        return self._apply_transform(trsf_to_apply, copy=copy)
 
-        return type(self)(transformed_shape)
 
-    def scale_to_unit_box(self):
+    def scale_to_unit_box(self, copy=True):
         """
         Translate and scale the Shape so it fits exactly 
         into the [-1, 1]^3 box
 
+        Args:
+            copy (bool)      True - Copy entities and apply the transform to
+                                        the underlying geometry
+                                False - Apply the transform to the topods Locator
+                                        if possible 
         Returns:
             The scaled version of this shape
         """
-        return self.scale_to_box(1.0)
+        return self.scale_to_box(1.0, copy=copy)
 
+
+def _apply_transform(self, trsf_to_apply, copy=True):
+    """
+    Apply the given transform to this Shape
+    """
+    apply_transform = BRepBuilderAPI_Transform(trsf_to_apply, Copy=copy)
+    apply_transform.Perform(self.topods_shape())
+    transformed_shape = apply_transform.ModifiedShape(self.topods_shape())
+
+    return type(self)(transformed_shape)
 
 def _find_closest_shape_in_list(shapes, datum):
     """

--- a/src/occwl/base.py
+++ b/src/occwl/base.py
@@ -591,31 +591,6 @@ class BoundingBoxMixin:
         brepbndlib_AddOptimal(self.topods_shape(), b, use_triangulation, use_shapetolerance)
         return geom_utils.box_to_geometry(b)
 
-
-    def transform(self, a, copy=True):
-        """
-        Apply the given 4x4 transform matrix to the solid
-
-        Args: a (nd.array) - Homogeneous transform matrix
-                             The transform that will be applied is
-                                        
-                             x' =  a[0,0]*x + a[0,1]*y + a[0,2]*z + a[0, 3]
-                             y' =  a[1,0]*x + a[1,1]*y + a[1,2]*z + a[1, 3]
-                             z' =  a[2,0]*x + a[2,1]*y + a[2,2]*z + a[2, 3]
-
-             copy (bool)    True - Copy entities and apply the transform to
-                                   the underlying geometry
-                            False - Apply the transform to the topods Locator
-                                    if possible 
-        """
-        trsf = gp_Trsf()
-        trsf.SetValues(
-            a[0,0], a[0,1], a[0,2], a[0, 3],
-            a[1,0], a[1,1], a[1,2], a[1, 3],
-            a[2,0], a[2,1], a[2,2], a[2, 3],
-        )
-        return self._apply_transform(trsf, copy=copy)
-
     def scale_to_box(self, box_side, copy=True):
         """
         Translate and scale the Shape so it fits exactly 
@@ -666,15 +641,7 @@ class BoundingBoxMixin:
         return self.scale_to_box(1.0, copy=copy)
 
 
-def _apply_transform(self, trsf_to_apply, copy=True):
-    """
-    Apply the given transform to this Shape
-    """
-    apply_transform = BRepBuilderAPI_Transform(trsf_to_apply, Copy=copy)
-    apply_transform.Perform(self.topods_shape())
-    transformed_shape = apply_transform.ModifiedShape(self.topods_shape())
 
-    return type(self)(transformed_shape)
 
 def _find_closest_shape_in_list(shapes, datum):
     """

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,36 @@
+"""
+Test the transform() function
+"""
+
+# System
+import numpy as np
+
+from occwl.solid import Solid
+
+# Test
+from tests.test_base import TestBase
+
+class TransformSolidTester(TestBase):
+    def test_scale_solid(self):
+        data_folder = self.test_folder() / "test_data"
+        self.run_test_on_all_files_in_folder(data_folder)
+
+    def run_test(self, solid):
+        box = solid.exact_box()
+
+        # Translate 1 model unit in x
+        mat = np.array([
+            [1, 0, 0, 1],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]
+        ])
+        transformed = solid.transform(mat)
+        transformed_box = transformed.exact_box()
+
+        tol = 0.01
+        dxmin = transformed_box.intervals[0].a - box.intervals[0].a
+        assert abs(dxmin -  1) < tol 
+
+        dxmax = transformed_box.intervals[0].b - box.intervals[0].b
+        assert abs(dxmax -  1) < tol 


### PR DESCRIPTION
# Why?
- I would like to release a new occwl version.   It's probably time for version 1.0.0
- Before releasing this I want to add a function to apply a transform 

# What?
- Updated the version number in `meta.yml` and `stepup.py`
- In the `Shape` base class add a function to transform a solid
- Add a unit test to check it works

# The copy flag
The `BRepBuilderAPI_Transform` code has two ways of transforming a solid.   If the transform determinant 1 then the underlying data is reused, but the  `Topo_DS` locators values get changed.  This has the advantage that some geometry is shared between the original and transformed shape.  It has the disadvantage that any function which queries points or vectors from the model needs to apply the transform from the locator.
In other cases the geometry is copied and "deep transformed".  This has the advantage that the locators remain as identify transforms.
The occwl library  will assert when querying geometry from a method if the transform is not set to the identity.

# Verification
All tests ran and passed
