### PR TITLE
Start to add some support for topods classes with non-identity transforms

### DIFF
--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -199,11 +199,11 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             OCC.Geom.Handle_Geom_*: Specific geometry type for the surface geometry
         """
-        loc = TopLoc_Location()
-        srf = BRepAdaptor_Surface(self.topods_shape(), loc)
-        assert loc.IsIdentity(), "Requesting surface for transformed face. \
+        assert self.topods_shape().Location().IsIdentity(), \
+            "Requesting surface for transformed face. \
             Call solid.set_transform_to_identity() to remove the transform \
             or compound.Transform(np.eye(4)) to bake in the assembly transform"
+        srf = BRepAdaptor_Surface(self.topods_shape())
         surf_type = self.surface_type()
         if surf_type == "plane":
             return srf.Plane()

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -176,7 +176,12 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             OCC.Geom.Handle_Geom_Surface: Interface to all surface geometry
         """
-        return BRep_Tool_Surface(self.topods_shape())
+        loc = TopLoc_Location()
+        surf = BRep_Tool_Surface(self.topods_shape(), loc)
+        assert loc.IsIdentity(), "Requesting surface for transformed face. \
+            Call solid.set_transform_to_identity() to remove the transform \
+            or compound.Transform(np.eye(4)) to bake in the assembly transform"
+        return surf
 
     def reversed_face(self):
         """
@@ -194,7 +199,11 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             OCC.Geom.Handle_Geom_*: Specific geometry type for the surface geometry
         """
-        srf = BRepAdaptor_Surface(self.topods_shape())
+        loc = TopLoc_Location()
+        srf = BRepAdaptor_Surface(self.topods_shape(), loc)
+        assert loc.IsIdentity(), "Requesting surface for transformed face. \
+            Call solid.set_transform_to_identity() to remove the transform \
+            or compound.Transform(np.eye(4)) to bake in the assembly transform"
         surf_type = self.surface_type()
         if surf_type == "plane":
             return srf.Plane()
@@ -223,7 +232,10 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             np.ndarray: 3D Point
         """
-        pt = self.surface().Value(uv[0], uv[1])
+        loc = TopLoc_Location()
+        surf = BRep_Tool_Surface(self.topods_shape(), loc)
+        pt = surf.Value(uv[0], uv[1])
+        pt = pt.Transformed(loc.Transformation())
         return geom_utils.gp_to_numpy(pt)
 
     def tangent(self, uv):
@@ -236,10 +248,14 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             Pair of np.ndarray or None: 3D unit vectors
         """
+        loc = TopLoc_Location()
+        surf = BRep_Tool_Surface(self.topods_shape(), loc)
         dU, dV = gp_Dir(), gp_Dir()
-        res = GeomLProp_SLProps(self.surface(), uv[0], uv[1], 1, 1e-9)
+        res = GeomLProp_SLProps(surf, uv[0], uv[1], 1, 1e-9)
         if res.IsTangentUDefined() and res.IsTangentVDefined():
             res.TangentU(dU), res.TangentV(dV)
+            dU.Transformed(loc.Transformation())
+            dV.Transformed(loc.Transformation())
             return (geom_utils.gp_to_numpy(dU)), (geom_utils.gp_to_numpy(dV))
         return None, None
 
@@ -253,10 +269,14 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             np.ndarray: 3D unit normal vector
         """
-        res = GeomLProp_SLProps(self.surface(), uv[0], uv[1], 1, 1e-9)
+        loc = TopLoc_Location()
+        surf = BRep_Tool_Surface(self.topods_shape(), loc)
+        res = GeomLProp_SLProps(surf, uv[0], uv[1], 1, 1e-9)
         if not res.IsNormalDefined():
             return (0, 0, 0)
-        normal = geom_utils.gp_to_numpy(res.Normal())
+        gp_normal = res.Normal()
+        gp_normal.Transformed(loc.Transformation())
+        normal = geom_utils.gp_to_numpy(gp_normal)
         if self.reversed():
             normal = -normal
         return normal
@@ -402,8 +422,13 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         Returns:
             np.ndarray: UV-coordinate
         """
-        uv = ShapeAnalysis_Surface(self.surface()).ValueOfUV(
-            gp_Pnt(pt[0], pt[1], pt[2]), 1e-9
+        loc = TopLoc_Location()
+        surf = BRep_Tool_Surface(self.topods_shape(), loc)
+        gp_pt = gp_Pnt(pt[0], pt[1], pt[2])
+        inv = loc.Transformation().Inverted()
+        gp_pt.Transformed(inv)
+        uv = ShapeAnalysis_Surface(surf).ValueOfUV(
+            gp_pt, 1e-9
         )
         return np.array(uv.Coord())
 

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -5,6 +5,7 @@ from occwl.edge import Edge
 from OCC.Extend.DataExchange import export_shape_to_svg
 from OCC.Core.gp import gp_Pnt, gp_Dir
 from deprecate import deprecated
+from OCC.Core.STEPControl import STEPControl_Writer
 
 
 @deprecated(target=None, deprecated_in="0.0.3", remove_in="0.0.5")

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -52,7 +52,7 @@ def save_step(list_of_solids, filename):
     step_writer = STEPControl_Writer()
     Interface_Static_SetCVal("write.step.schema", "AP203")
     for solid in list_of_solids:
-        assert isinstance(solid, Solid)
+        assert isinstance(solid, (Solid, Compound))
         step_writer.Transfer(solid.topods_shape(), STEPControl_AsIs)
     status = step_writer.Write(str(filename))
     return status == IFSelect_RetDone

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -7,6 +7,7 @@ from OCC.Core.gp import gp_Pnt, gp_Dir
 from deprecate import deprecated
 from OCC.Core.STEPControl import STEPControl_Writer, STEPControl_AsIs
 from OCC.Core.Interface import Interface_Static_SetCVal
+from OCC.Core.IFSelect import IFSelect_RetDone
 
 
 @deprecated(target=None, deprecated_in="0.0.3", remove_in="0.0.5")

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -6,6 +6,7 @@ from OCC.Extend.DataExchange import export_shape_to_svg
 from OCC.Core.gp import gp_Pnt, gp_Dir
 from deprecate import deprecated
 from OCC.Core.STEPControl import STEPControl_Writer
+from OCC.Core.Interface import Interface_Static_SetCVal
 
 
 @deprecated(target=None, deprecated_in="0.0.3", remove_in="0.0.5")

--- a/src/occwl/io.py
+++ b/src/occwl/io.py
@@ -5,7 +5,7 @@ from occwl.edge import Edge
 from OCC.Extend.DataExchange import export_shape_to_svg
 from OCC.Core.gp import gp_Pnt, gp_Dir
 from deprecate import deprecated
-from OCC.Core.STEPControl import STEPControl_Writer
+from OCC.Core.STEPControl import STEPControl_Writer, STEPControl_AsIs
 from OCC.Core.Interface import Interface_Static_SetCVal
 
 

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -8,6 +8,7 @@ from OCC.Core.BRepExtrema import BRepExtrema_DistShapeShape
 from OCC.Core.Extrema import Extrema_ExtFlag_MIN
 from OCC.Core.gp import gp_Ax1, gp_Trsf
 from OCC.Core.TopAbs import TopAbs_REVERSED
+from OCC.Core.TopLoc import TopLoc_Location
 from OCC.Core.TopoDS import (
     TopoDS_Edge,
     TopoDS_Face,
@@ -261,6 +262,33 @@ class Shape:
         if return_analyzer:
             return analyzer.IsValid(), analyzer
         return analyzer.IsValid()
+
+
+
+    def set_transform_to_identity(self):
+        """
+        When an assembly is loaded from a STEP file
+        the solids will be transformed relative to
+        their local coordinate system.   i.e. they
+        are placed in the assembly root components 
+        coordinate system.
+
+        When working with individual bodies you often
+        want them to be axis aligned, in which case 
+        you want to remove the assembly transform.
+        This function removes it for you.
+
+        If however you want to bake the transform
+        into the bodies and suppress the asserts 
+        from parts of occwl which don't cope with
+        transforms then use the transform() function
+        below with copy=True
+        """
+        identity = TopLoc_Location()
+        self.topods_shape().Location(identity)
+        self._top_exp = TopologyUtils.TopologyExplorer(self.topods_shape(), True)
+
+        
 
     def transform(self, a, copy=True):
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -22,7 +22,7 @@ class TestBase(unittest.TestCase):
         return solids[0]
 
     def run_test_on_all_files_in_folder(self, folder):
-        step_files = [f for f in folder.glob("*.step")]
+        step_files = [f for f in folder.glob("**/*.step")]
         stp_files = [f for f in folder.glob("*.stp")]
         step_files.extend(stp_files)
 
@@ -33,6 +33,7 @@ class TestBase(unittest.TestCase):
             print(f"Running tests for {file.stem}{file.suffix}")
             solids = list(Compound.load_from_step(file).solids())
             for solid in solids:
+                solid.set_transform_to_identity()
                 self.run_test_with_pathname(file, solid)
 
     def run_test_on_solid_from_filename(self, filename):

--- a/tests/test_grid_and_normals.py
+++ b/tests/test_grid_and_normals.py
@@ -25,6 +25,7 @@ class GridTester(TestBase):
         num_v = 10
         pts = uvgrid(face, num_u, num_v, method="point")
         nor = uvgrid(face, num_u, num_v, method="normal")
+        length_eps = 1e-3
         if pts is not None and nor is not None:
             g = np.concatenate((pts, nor), axis=2)
             self.reverse_u_test(g)
@@ -36,6 +37,9 @@ class GridTester(TestBase):
                     du = pt10 - pt00
                     dv = pt01 - pt00
                     approx_normal = np.cross(du, dv)
+                    if np.linalg.norm(approx_normal) < length_eps:
+                        # We can't do this test for very small vectors
+                        continue
                     normal = np.array(g[i, j, 3:6])
                     angle = self.angle_between_vectors(approx_normal, normal)
 


### PR DESCRIPTION
# Why?

The open cascade `TopoDS_Shape` class contains a `Location()` which may not be an identity transform.   Lots of occwl functions don't look at the location and so they don't correctly apply the transform to any of the geometry.

# What?

In [shape.py](src/occwl/shape.py) add a function `set_transform_to_identity()`.  This just sets the transform to the identity and rebuilds the topology explorer.  As the transform on a parent entity is propagated to the children,  transforms on the faces of a solid will go back to the identity if this function is called on the solid.

If you want to keep the transform from the assembly then call `Shape.transform(np.eye(4))` to bake the transform into all child entities.

Should merge PR#19 before applying this one
