### PR TITLE
Return normals from get_triangles()

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,5 @@ dependencies:
   - networkx
   - wxPython
   - pydeprecate
+  - trimesh
+  - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -10,5 +10,3 @@ dependencies:
   - networkx
   - wxPython
   - pydeprecate
-  - trimesh
-  - scipy

--- a/tests/test_face.py
+++ b/tests/test_face.py
@@ -1,6 +1,9 @@
 # System
 import numpy as np
 
+# OCC
+from occwl.compound import Compound
+
 # Test
 from tests.test_base import TestBase
 
@@ -10,12 +13,59 @@ class FaceTester(TestBase):
         data_folder = self.test_folder() / "test_data"
         self.run_test_on_all_files_in_folder(data_folder)
 
+    def test_get_triangles(self):
+        """ Test getting triangles from a face """
+        # Test a single block
+        block_file = self.test_folder() / "test_data/block.step"
+        solids = list(Compound.load_from_step(block_file).solids())
+        for solid in solids:
+            solid.triangulate_all_faces()
+            faces = solid.faces()
+            for face in faces:
+                # Check getting triangles without normals
+                verts, tris = face.get_triangles()
+                self.assertIsInstance(verts, np.ndarray)
+                self.assertIsInstance(tris, np.ndarray)
+                self.assertEqual(verts.shape[1], 3)
+                self.assertEqual(tris.shape[1], 3)
+                # Check getting triangles with normals
+                verts, tris, normals = face.get_triangles(return_normals=True)
+                self.assertIsInstance(normals, np.ndarray)
+                self.assertEqual(normals.shape[1], 3)
+                # Check the normals are close to 1.0 length
+                lengths = np.linalg.norm(normals, axis=1)
+                self.assertTrue(np.allclose(lengths, np.ones(lengths.shape)))
+                # Test the values of the normals of the six sides of the block
+                # Top of block - assuming Y-Up
+                if np.all(np.isclose(verts[:,1], 50)):
+                    # Point up along Y
+                    self.assertTrue(np.all(np.isclose(normals[:,1], 1)))
+                # Bottom of block
+                elif np.all(np.isclose(verts[:,1], 0)):
+                    # Point down along Y
+                    self.assertTrue(np.all(np.isclose(normals[:,1], -1)))
+                # Vertical side
+                elif np.all(np.isclose(verts[:,0], 50)):
+                    # Point out from X
+                    self.assertTrue(np.all(np.isclose(normals[:,0], 1)))                    
+                # Vertical side
+                elif np.all(np.isclose(verts[:,0], 0)):
+                    # Point back from X
+                    self.assertTrue(np.all(np.isclose(normals[:,0], -1)))   
+                # Vertical side
+                elif np.all(np.isclose(verts[:,2], 40)):
+                    # Point out from Z
+                    self.assertTrue(np.all(np.isclose(normals[:,2], 1)))
+                # Vertical side
+                elif np.all(np.isclose(verts[:,2], 0)):
+                    # Point back from Z
+                    self.assertTrue(np.all(np.isclose(normals[:,2], -1)))                                                         
+
     def perform_is_left_of_test(self, solid):
         for face in solid.faces():
             for wire in face.wires():
                 for edge in wire.ordered_edges():
                     self.assertTrue(face.is_left_of(edge))
-
 
     def perform_tests_on_face(self, face):
         uv_box = face.uv_bounds()

--- a/tests/test_face.py
+++ b/tests/test_face.py
@@ -32,6 +32,7 @@ class FaceTester(TestBase):
                 verts, tris, normals = face.get_triangles(return_normals=True)
                 self.assertIsInstance(normals, np.ndarray)
                 self.assertEqual(normals.shape[1], 3)
+                self.assertEqual(verts.shape[0], normals.shape[0])
                 # Check the normals are close to 1.0 length
                 lengths = np.linalg.norm(normals, axis=1)
                 self.assertTrue(np.allclose(lengths, np.ones(lengths.shape)))


### PR DESCRIPTION
# Why?
For rendering purposes it is helpful to generate vertex normals when triangulating faces.

# What?
Adds the the `return_normals` option to `face.get_triangles()`. By default this is set to False and returns a tuple `(verts, tris)` that is backwards compatible. If `return_normals` is set to `True` the normals are also returned i.e. `(verts, tris, normals)`.