### PR TITLE
Get edge polyline

### DIFF
--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -458,7 +458,7 @@ class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):
 
         return left_face, right_face
 
-    def get_polyline(self, deflection=0.2, algorithm="QuasiUniformDeflection"):
+    def get_polyline(self, deflection=0.0005, algorithm="QuasiUniformDeflection"):
         """
         Get a polyline, represented as a sequence of points, from this edge
 

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -1,4 +1,5 @@
 # System
+import unittest
 import numpy as np
 
 # Geometry
@@ -10,7 +11,7 @@ from OCC.Core.Geom import Geom_Circle
 from OCC.Core.GeomAbs import GeomAbs_Circle
 from occwl.edge import Edge
 from occwl.solid import Solid
-from occwl.compound import Compound
+from occwl.viewer import Viewer
 
 # Test
 from tests.test_base import TestBase
@@ -135,6 +136,21 @@ class EdgeTester(TestBase):
                 self.assertEqual(pts.shape[1], 3)
                 self.assertGreater(pts.shape[0], 0)
 
+    @unittest.skip("Skipping visualization")
+    def test_view_get_polyline(self):
+        """ View the output from get_polyline """
+        # NOTE: On mac this needs to be run using 'pythonw' rather than 'python'
+        solid = Solid.make_cone(1.0, 0.0, 1.0)
+        v = Viewer(backend="wx")
+        v.display(solid, transparency=0.8)
+
+        edges = solid.edges()
+        for edge in edges:
+            pts = edge.get_polyline()
+            for pt in pts:
+                v.display(Solid.make_sphere(center=pt, radius=0.01))
+        v.fit()
+        v.show()
 
     def run_test(self, solid):
         edges = solid.edges()


### PR DESCRIPTION
# Why?
When rendering it is helpful to create polyline approximations of edges to show the B-Rep face boundaries.

# What?
This PR adds a new method `edge.get_polyline()` that returns a discrete sequence of points that can be used to create a polyline.

I've set the default deflection value `0.0005` (units unknown) to be relatively low to produce a more accurate result. Here is what it looks like when drawing a cone with height and width of 1.0.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/619336/183519171-7912d8d9-ea62-4173-a219-4d3251764a3b.png">

If I increase the size of the cone to height and width 10 we get a lot more points. So the deflection is some absolute value that will need to be set depending on the size of the model.

<img width="681" alt="image" src="https://user-images.githubusercontent.com/619336/183519947-a02024c9-e9b0-4ad3-b388-cfd090785517.png">


