### PR TITLE
Return value fixes for get_triangles / get_polyline 

### DIFF
--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -474,7 +474,7 @@ class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):
         """
         # If we don't have a valid curve, return an empty array
         if not self.has_curve():
-            return np.empty(shape=(0,0), dtype=np.float32)
+            return np.empty(shape=(0,3), dtype=np.float32)
         
         curve_adaptor = BRepAdaptor_Curve(self.topods_shape())
         first_param = curve_adaptor.FirstParameter()

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -532,7 +532,17 @@ class Face(Shape, BoundingBoxMixin, TriangulatorMixin, WireContainerMixin, \
         bt = BRep_Tool()
         facing = bt.Triangulation(self.topods_shape(), location)
         if facing == None:
-            return [], []
+            if return_normals:
+                return (
+                    np.empty(shape=(0,3), dtype=np.float32),
+                    np.empty(shape=(0,3), dtype=np.int32),
+                    np.empty(shape=(0,3), dtype=np.float32)
+                )
+            else:
+                return (
+                    np.empty(shape=(0,3), dtype=np.float32),
+                    np.empty(shape=(0,3), dtype=np.int32)
+                )
 
         vert_nodes = facing.Nodes()
         tri = facing.Triangles()

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -131,7 +131,7 @@ class EdgeTester(TestBase):
             pts = edge.get_polyline()
             self.assertIsInstance(pts, np.ndarray)
             if not edge.has_curve():
-                self.assertEqual(pts.shape, (0,0))
+                self.assertEqual(pts.shape, (0,3))
             else:
                 self.assertEqual(pts.shape[1], 3)
                 self.assertGreater(pts.shape[0], 0)


### PR DESCRIPTION
# Why?
`get_triangles()` was returning the incorrect number of values and also differed from what was returned by `get_polyline()` for failure cases.

# What?
- Return the correct number of values when `get_triangles(return_normals=True)`
- Return empty numpy arrays of shape `(0,3)` for failure cases to keep things consistent