### PR TITLE
Remove specific version of ipykernel.  Update to version 2.0.0

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "occwl" %}
-{% set version = "1.0.0" %}
+{% set version = "2.0.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -28,7 +28,7 @@ requirements:
     - pydeprecate
     - networkx
     - matplotlib
-    - ipykernel =6.3.1
+    - ipykernel
     - jupyter
     - ipython
     - pythreejs

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="occwl",  # package name
-    version="1.0.0",
+    version="2.0.0",
     author="Pradeep Kumar Jayaraman, Joseph G. Lambourne",
     author_email="pradeep.kumar.jayaraman@autodesk.com, joseph.lambourne@autodesk.com",
     description="Lightweight Pythonic wrapper around pythonocc",


### PR DESCRIPTION
I was investigating the hang creating the python environment in  #26.  Before removing the version number for ipykernel I was unable to build the conda package.   After removing the version number I was able to build and publish the conda package, but when I try a test install then it appears to hang

The version number is also updated to 2.0.0 because of the asserts added in [PR#20](https://github.com/AutodeskAILab/occwl/pull/20)

As v2.0.0 is now live, this change is needed to keep the source code up to date