### PR TITLE
Check if item is None

### DIFF
--- a/src/occwl/compound.py
+++ b/src/occwl/compound.py
@@ -78,6 +78,8 @@ class Compound(Shape, BottomUpFaceIterator, BoundingBoxMixin, BottomUpEdgeIterat
                 if item is None:
                     continue
                 item = StepRepr_RepresentationItem.DownCast(item)
+                if item is None:
+                    continue
                 name = item.Name().ToCString()
                 occwl_shape = Shape.occwl_shape(s)
                 occwl_shape_to_attributes[occwl_shape] = {


### PR DESCRIPTION
I encountered this error when trying to load a STEP file:
```
File "compound.py", line 90, in load_step_with_attributes
  check_shape_type(TopAbs_SOLID)
File "compound.py", line 81, in check_shape_type
name = item.Name().ToCString()
AttributeError: 'NoneType' object has no attribute 'Name'
```
So added a check to see if `item` is None.