### PR TITLE
PythonOCC v7.8.1 upgrade

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.4
+FROM --platform=linux/amd64 python:3.9 as base
+
+RUN python -m pip install --upgrade pip
+
+FROM base as dev
+
+# Insgtall OCC requirements
+RUN apt-get update
+RUN  apt-get install -y ffmpeg libsm6 libxext6
+
+# Install conda
+RUN mkdir -p ~/miniconda3 && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
+    bash ~/miniconda3/miniconda.sh -b -u -p /miniconda3 && \
+    rm -rf ~/miniconda3/miniconda.sh && \
+    /miniconda3/bin/conda init bash
+
+ARG PROJ_DIR=/proj
+ARG PIP_CACHE=/root/.cache/pip
+WORKDIR ${PROJ_DIR}
+
+# Create conda environment
+COPY environment.yml .
+RUN --mount=type=cache,target=/miniconda3/pkgs,id=conda \
+    /miniconda3/bin/conda env create -f environment.yml
+SHELL ["conda", "run", "--no-capture-output", "-n", "occwl_dev", "/bin/bash", "-c"]
+
+# Install Python dependencies
+# COPY setup.py .
+# RUN mkdir -p ${PROJ_DIR}/src
+# RUN --mount=type=cache,target=${PIP_CACHE},id=pip \
+#     /miniconda3/bin/conda run -n occwl_dev python -m \
+#     pip install -v --cache-dir ${PIP_CACHE} -e .
+
+ENTRYPOINT [ "/bin/bash", "-c" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "Alpine",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "occ_dev:7.8.1",
+	"build": {
+		// this requires ../docker/Dockerfile to be built to brep_directgen:dev tag.
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"charliermarsh.ruff",
+				"eamodio.gitlens",
+				"github.vscode-pull-request-github",
+				"ms-python.debugpy",
+				"ms-python.python",
+				"ms-toolsai.jupyter",
+				"streetsidesoftware.code-spell-checker",
+				"ms-azuretools.vscode-docker",
+				"github.copilot"
+			],
+			"settings": {
+				"extensions.verifySignature": false,
+				"[python]": {
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+						"source.fixAll": "explicit",
+						"source.organizeImports": "explicit"
+					},
+					"editor.defaultFormatter": "charliermarsh.ruff"
+				}
+			}
+		}
+	},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OCCWL is a simple, lightweight Pythonic wrapper around pythonocc (python binding
 ## Installing our conda package
 
 ```
-conda create --name=myoccwlenv python=3.7
+conda create --name=myoccwlenv python=3.9
 source activate myoccwlenv
 conda install -c lambouj -c conda-forge occwl
 ```

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "occwl" %}
-{% set version = "2.1.0" %}
+{% set version = "3.0.0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
   run:
     - python >=3.7
-    - pythonocc-core =7.5.1
+    - pythonocc-core =7.8.1
     - numpy
     - pyqt >=5
     - wxpython >=4

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.9
   - numpy
-  - pythonocc-core=7.5.1
+  - pythonocc-core=7.8.1
   - networkx
   - wxPython
   - pydeprecate

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="occwl",  # package name
-    version="2.1.0",
+    version="3.0.0",
     author="Pradeep Kumar Jayaraman, Joseph G. Lambourne",
     author_email="pradeep.kumar.jayaraman@autodesk.com, joseph.lambourne@autodesk.com",
     description="Lightweight Pythonic wrapper around pythonocc",

--- a/src/occwl/base.py
+++ b/src/occwl/base.py
@@ -1,14 +1,10 @@
 import numpy as np
 
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Pnt2d, gp_Ax2
+from OCC.Core.gp import gp
 from OCC.Core.Bnd import Bnd_Box
-from OCC.Core.BRepBndLib import brepbndlib_Add, brepbndlib_AddOptimal
+from OCC.Core.BRepBndLib import brepbndlib
 from OCC.Extend import TopologyUtils
-from OCC.Core.BRepGProp import (
-    brepgprop_LinearProperties,
-    brepgprop_SurfaceProperties,
-    brepgprop_VolumeProperties,
-)
+from OCC.Core.BRepGProp import brepgprop
 from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
 from OCC.Core.GProp import GProp_GProps
 from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Ax1, gp_Vec, gp_Trsf
@@ -498,7 +494,7 @@ class SurfacePropertiesMixin:
             float: Area
         """
         geometry_properties = GProp_GProps()
-        brepgprop_SurfaceProperties(self.topods_shape(), geometry_properties)
+        brepgprop.SurfaceProperties(self.topods_shape(), geometry_properties)
         return geometry_properties.Mass()
 
 
@@ -517,7 +513,7 @@ class VolumePropertiesMixin:
             float: Volume
         """
         props = GProp_GProps()
-        brepgprop_VolumeProperties(self.topods_shape(), props, tolerance)
+        brepgprop.VolumeProperties(self.topods_shape(), props, tolerance)
         return props.Mass()
 
     def center_of_mass(self, tolerance=1e-9):
@@ -532,7 +528,7 @@ class VolumePropertiesMixin:
         """
         from occwl.geometry import geom_utils
         props = GProp_GProps()
-        brepgprop_VolumeProperties(self.topods_shape(), props, tolerance)
+        brepgprop.VolumeProperties(self.topods_shape(), props, tolerance)
         com = props.CentreOfMass()
         return geom_utils.gp_to_numpy(com)
 
@@ -550,7 +546,7 @@ class VolumePropertiesMixin:
         """
         from occwl.geometry import geom_utils
         props = GProp_GProps()
-        brepgprop_VolumeProperties(self.topods_shape(), props, tolerance)
+        brepgprop.VolumeProperties(self.topods_shape(), props, tolerance)
         axis = gp_Ax1(
             geom_utils.numpy_to_gp(point), geom_utils.numpy_to_gp_dir(direction)
         )
@@ -571,7 +567,7 @@ class BoundingBoxMixin:
         """
         from occwl.geometry import geom_utils
         b = Bnd_Box()
-        brepbndlib_Add(self.topods_shape(), b)
+        brepbndlib.Add(self.topods_shape(), b)
         return geom_utils.box_to_geometry(b)
 
     def exact_box(self, use_shapetolerance=False):
@@ -588,7 +584,7 @@ class BoundingBoxMixin:
         from occwl.geometry import geom_utils
         b = Bnd_Box()
         use_triangulation = True
-        brepbndlib_AddOptimal(self.topods_shape(), b, use_triangulation, use_shapetolerance)
+        brepbndlib.AddOptimal(self.topods_shape(), b, use_triangulation, use_shapetolerance)
         return geom_utils.box_to_geometry(b)
 
     def scale_to_box(self, box_side, copy=True):

--- a/src/occwl/base.py
+++ b/src/occwl/base.py
@@ -1,16 +1,13 @@
 import numpy as np
 
-from OCC.Core.gp import gp
 from OCC.Core.Bnd import Bnd_Box
 from OCC.Core.BRepBndLib import brepbndlib
-from OCC.Extend import TopologyUtils
 from OCC.Core.BRepGProp import brepgprop
 from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
 from OCC.Core.GProp import GProp_GProps
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Ax1, gp_Vec, gp_Trsf
+from OCC.Core.gp import gp_Pnt, gp_Ax1, gp_Vec, gp_Trsf
 from OCC.Core.ShapeUpgrade import ShapeUpgrade_ShapeDivideClosed
 from OCC.Core.ShapeUpgrade import ShapeUpgrade_ShapeDivideClosedEdges
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_Transform
 
 
 class VertexContainerMixin:

--- a/src/occwl/batch/render_multiview.py
+++ b/src/occwl/batch/render_multiview.py
@@ -6,9 +6,6 @@ from itertools import repeat
 from multiprocessing import Pool
 from occwl.compound import Compound
 from occwl.viewer import OffscreenRenderer
-from OCC.Core.gp import gp_Dir, gp_Vec
-from OCC.Core.V3d import V3d_DirectionalLight
-from OCC.Core.Quantity import Quantity_Color, Quantity_TOC_RGB, Quantity_NOC_WHITE
 from tqdm import tqdm
 
 

--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Vec, gp_Pnt2d, gp_Ax2, gp_Circ
-from OCC.Core.BRep import BRep_Tool, BRep_Tool_Curve, BRep_Tool_Continuity
+from OCC.Core.BRep import BRep_Tool
 from OCC.Core.BRepAdaptor import BRepAdaptor_Curve
-from OCC.Core.BRepGProp import brepgprop_LinearProperties
+from OCC.Core.BRepGProp import brepgprop
 from OCC.Core.GC import GC_MakeArcOfCircle
 from OCC.Core.GProp import GProp_GProps
 from OCC.Core.GeomAbs import (
@@ -217,7 +217,7 @@ class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):
         if not self.has_curve():
             return 0.0
         geometry_properties = GProp_GProps()
-        brepgprop_LinearProperties(self.topods_shape(), geometry_properties)
+        brepgprop.LinearProperties(self.topods_shape(), geometry_properties)
         return geometry_properties.Mass()
 
     def curve(self):
@@ -227,7 +227,7 @@ class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):
         Returns:
             OCC.Geom.Handle_Geom_Curve: Interface to all curve geometry
         """
-        return BRep_Tool_Curve(self.topods_shape())[0]
+        return BRep_Tool.Curve(self.topods_shape())[0]
 
     def specific_curve(self):
         """
@@ -278,7 +278,7 @@ class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):
         if not self.has_curve():
             # Return an empty interval
             return Interval()
-        _, umin, umax = BRep_Tool_Curve(self.topods_shape())
+        _, umin, umax = BRep_Tool.Curve(self.topods_shape())
         return Interval(umin, umax)
 
     def reversed_edge(self):
@@ -363,7 +363,7 @@ class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):
         Returns:
             GeomAbs_Shape: enum describing the continuity order
         """
-        return BRep_Tool_Continuity(
+        return BRep_Tool.Continuity(
             self.topods_shape(), face1.topods_shape(), face2.topods_shape()
         )
 

--- a/src/occwl/edge.py
+++ b/src/occwl/edge.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Vec, gp_Pnt2d, gp_Ax2, gp_Circ
+from OCC.Core.gp import gp_Pnt, gp_Vec, gp_Ax2, gp_Circ
 from OCC.Core.BRep import BRep_Tool
 from OCC.Core.BRepAdaptor import BRepAdaptor_Curve
 from OCC.Core.BRepGProp import brepgprop
@@ -17,11 +17,7 @@ from OCC.Core.GeomAbs import (
     GeomAbs_OffsetCurve,
     GeomAbs_OtherCurve,
 )
-from OCC.Core.TopAbs import TopAbs_REVERSED
-from OCC.Extend import TopologyUtils
 from OCC.Core.TopoDS import TopoDS_Edge
-from OCC.Core.GCPnts import GCPnts_AbscissaPoint
-from OCC.Core.BRepAdaptor import BRepAdaptor_Curve
 from OCC.Core.ShapeAnalysis import ShapeAnalysis_Edge
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 from OCC.Core.GCPnts import (
@@ -35,8 +31,6 @@ import occwl.vertex
 from occwl.geometry.interval import Interval
 from occwl.shape import Shape
 from occwl.base import VertexContainerMixin, BoundingBoxMixin
-from deprecate import deprecated
-import logging
 
 
 class Edge(Shape, VertexContainerMixin, BoundingBoxMixin):

--- a/src/occwl/edge_data_extractor.py
+++ b/src/occwl/edge_data_extractor.py
@@ -7,13 +7,11 @@ from enum import Enum
 import numpy as np
 
 # OCC
-from OCC.Core.BRepAdaptor import BRepAdaptor_Curve2d, BRepAdaptor_Surface
-from OCC.Core.gp import gp_Pnt2d, gp_Identity
+from OCC.Core.BRepAdaptor import BRepAdaptor_Curve2d
+from OCC.Core.gp import gp_Pnt2d
 
 # occwl
-from occwl.geometry.interval import Interval
 from occwl.geometry.arc_length_param_finder import ArcLengthParamFinder
-import occwl.geometry.geom_utils as geom_utils 
 
 class EdgeConvexity(Enum):
     CONCAVE = 1

--- a/src/occwl/face.py
+++ b/src/occwl/face.py
@@ -1,7 +1,4 @@
-import logging
-
 import numpy as np
-from deprecate import deprecated
 from OCC.Core.BRep import BRep_Tool
 from OCC.Core.BRepAdaptor import BRepAdaptor_Surface
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
@@ -17,9 +14,9 @@ from OCC.Core.GeomAbs import (GeomAbs_BezierSurface, GeomAbs_BSplineSurface,
                               GeomAbs_Sphere, GeomAbs_SurfaceOfExtrusion,
                               GeomAbs_SurfaceOfRevolution, GeomAbs_Torus)
 from OCC.Core.GeomLProp import GeomLProp_SLProps
-from OCC.Core.gp import gp_Dir, gp_Pnt, gp_Pnt2d, gp_TrsfForm
+from OCC.Core.gp import gp_Dir, gp_Pnt, gp_Pnt2d
 from OCC.Core.ShapeAnalysis import ShapeAnalysis_Surface
-from OCC.Core.TopAbs import TopAbs_IN, TopAbs_REVERSED
+from OCC.Core.TopAbs import TopAbs_IN
 from OCC.Core.TopLoc import TopLoc_Location
 from OCC.Core.TopoDS import TopoDS_Face
 

--- a/src/occwl/jupyter_viewer.py
+++ b/src/occwl/jupyter_viewer.py
@@ -1,10 +1,9 @@
 import numpy as np
-import math
 import sys
 import uuid
 
-from typing import Any, Callable, List, Optional, Tuple
-from OCC.Core.TopoDS import TopoDS_Vertex, TopoDS_Edge, TopoDS_Face, TopoDS_Shell, TopoDS_Solid
+from typing import Optional, Tuple
+from OCC.Core.TopoDS import TopoDS_Edge, TopoDS_Face
 
 from OCC.Display.WebGl.jupyter_renderer import JupyterRenderer
 
@@ -12,12 +11,9 @@ from matplotlib.cm import get_cmap
 from matplotlib.colors import Normalize
 from matplotlib.colors import rgb2hex
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from occwl.vertex import Vertex
 from occwl.edge import Edge
 from occwl.face import Face
-from occwl.solid import Solid
 
 # pythreejs
 try:

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -7,7 +7,6 @@ from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeVertex
 from OCC.Core.BRepExtrema import BRepExtrema_DistShapeShape
 from OCC.Core.BRepTools import BRepTools_ShapeSet
 from OCC.Core.Extrema import Extrema_ExtFlag_MIN
-from OCC.Core.Message import Message_ProgressRange
 from OCC.Core.gp import gp_Ax1, gp_Trsf
 from OCC.Core.TopAbs import TopAbs_REVERSED
 from OCC.Core.TopLoc import TopLoc_Location

--- a/src/occwl/solid.py
+++ b/src/occwl/solid.py
@@ -1,11 +1,9 @@
-import numpy as np
-
 from OCC.Core.TopoDS import (
     TopoDS_Solid,
     TopoDS_Compound,
     TopoDS_CompSolid,
 )
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Pnt2d, gp_Ax2
+from OCC.Core.gp import gp_Ax2
 import math
 from occwl.base import VertexContainerMixin, EdgeContainerMixin, \
             WireContainerMixin, FaceContainerMixin, BottomUpFaceIterator, \
@@ -14,8 +12,6 @@ from occwl.base import VertexContainerMixin, EdgeContainerMixin, \
 
 from occwl.geometry import geom_utils
 from occwl.shape import Shape
-from deprecate import deprecated
-import logging
 
 
 class Solid(Shape, VertexContainerMixin, EdgeContainerMixin, ShellContainerMixin, \

--- a/src/occwl/uvgrid.py
+++ b/src/occwl/uvgrid.py
@@ -1,8 +1,4 @@
 import numpy as np
-from OCC.Core.gp import gp_Identity
-
-from occwl.face import Face
-from occwl.edge import Edge
 
 
 def _uvgrid_reverse_u(grid):

--- a/src/occwl/vertex.py
+++ b/src/occwl/vertex.py
@@ -1,12 +1,9 @@
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Pnt2d
 from OCC.Core.TopoDS import TopoDS_Vertex
 from OCC.Core.BRep import BRep_Tool
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeVertex
-import logging
 
 from occwl.geometry import geom_utils
 from occwl.shape import Shape
-from deprecate import deprecated
 
 
 class Vertex(Shape):

--- a/src/occwl/viewer.py
+++ b/src/occwl/viewer.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Any, Callable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
-from OCC.Core.AIS import AIS_Line, AIS_Point, AIS_Shaded, AIS_WireFrame, AIS_Axis
+from OCC.Core.AIS import AIS_Line, AIS_Point, AIS_Shaded, AIS_WireFrame
 from OCC.Core.Aspect import (
     Aspect_TOL_DASH,
     Aspect_TOL_DOT,
@@ -19,7 +19,7 @@ from OCC.Core.Graphic3d import (
     Graphic3d_TOSM_FACET,
     Graphic3d_TOSM_FRAGMENT
 )
-from OCC.Core.gp import gp_Ax1, gp_Dir
+from OCC.Core.gp import gp_Dir
 from OCC.Core.Geom import Geom_CartesianPoint, Geom_Line
 from OCC.Core.Prs3d import Prs3d_LineAspect, Prs3d_PointAspect
 from OCC.Core.Quantity import Quantity_Color, Quantity_TOC_RGB

--- a/src/occwl/wire.py
+++ b/src/occwl/wire.py
@@ -5,8 +5,6 @@ from occwl.edge import Edge
 from occwl.vertex import Vertex
 
 from occwl.shape import Shape
-from deprecate import deprecated
-import logging
 
 
 class Wire(Shape):

--- a/tests/test_arc_length_param_finder.py
+++ b/tests/test_arc_length_param_finder.py
@@ -9,7 +9,6 @@ from OCC.Extend.ShapeFactory import point_list_to_TColgp_Array1OfPnt
 
 # occwl
 from occwl.geometry.interval import Interval
-from occwl.edge_data_extractor import EdgeDataExtractor, EdgeConvexity
 from occwl.edge import Edge
 from occwl.geometry.arc_length_param_finder import ArcLengthParamFinder
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,5 +1,4 @@
 # System
-from pathlib import Path
 import numpy as np
 
 # OCC

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -1,5 +1,4 @@
 from occwl.compound import Compound
-from occwl.io import load_single_compound_from_step
 
 # Test
 from tests.test_base import TestBase

--- a/tests/test_convert_geometric_identity.py
+++ b/tests/test_convert_geometric_identity.py
@@ -2,9 +2,6 @@
 Test for convert_geometric_identity_transforms_to_identity()
 """
 # System
-import numpy as np
-from pathlib import Path
-
 from occwl.compound import Compound
 
 # Test

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -4,7 +4,7 @@ import numpy as np
 
 # Geometry
 from occwl.geometry.interval import Interval
-from OCC.Core.gp import gp_XOY, gp_Pnt
+from OCC.Core.gp import gp, gp_Pnt
 from OCC.Core.GC import GC_MakeSegment
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 from OCC.Core.Geom import Geom_Circle
@@ -71,7 +71,7 @@ class EdgeTester(TestBase):
 
     def _test_closed_periodic(self):
         # Circle
-        circle = BRepBuilderAPI_MakeEdge(Geom_Circle(gp_XOY(), 1)).Edge()
+        circle = BRepBuilderAPI_MakeEdge(Geom_Circle(gp.XOY(), 1)).Edge()
         circle = Edge(circle)
         is_closed = circle.closed_curve()
         is_periodic = circle.periodic()
@@ -90,7 +90,7 @@ class EdgeTester(TestBase):
         self.assertTrue(not is_periodic)
 
     def _test_curve_type(self):
-        circle = BRepBuilderAPI_MakeEdge(Geom_Circle(gp_XOY(), 1)).Edge()
+        circle = BRepBuilderAPI_MakeEdge(Geom_Circle(gp.XOY(), 1)).Edge()
         circle = Edge(circle)
         curve_type = circle.curve_type()
         curve_type_enum = circle.curve_type_enum()

--- a/tests/test_edge_data_extractor.py
+++ b/tests/test_edge_data_extractor.py
@@ -5,15 +5,9 @@ import sys
 # OCC
 from OCC.Core.Quantity import (
     Quantity_Color,
-    Quantity_TOC_RGB,
-    Quantity_NOC_WHITE,
-    Quantity_NOC_BLACK,
     Quantity_NOC_BLUE1,
-    Quantity_NOC_CYAN1,
     Quantity_NOC_RED,
     Quantity_NOC_GREEN,
-    Quantity_NOC_ORANGE,
-    Quantity_NOC_YELLOW,
 )
 
 

--- a/tests/test_entity_mapper.py
+++ b/tests/test_entity_mapper.py
@@ -3,7 +3,6 @@ from OCC.Extend.TopologyUtils import TopologyExplorer, WireExplorer
 
 # occwl
 from occwl.entity_mapper import EntityMapper
-from occwl.solid import Solid
 from occwl.face import Face
 from occwl.edge import Edge
 from occwl.wire import Wire

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,12 +1,4 @@
-# System
-import numpy as np
-
 # Geometry
-from occwl.geometry.interval import Interval
-from OCC.Core.gp import gp_XOY, gp_Pnt
-from OCC.Core.GC import GC_MakeSegment
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
-from OCC.Core.Geom import Geom_Circle
 from occwl.graph import vertex_adjacency, face_adjacency
 
 # Test

--- a/tests/test_grid_and_normals.py
+++ b/tests/test_grid_and_normals.py
@@ -1,9 +1,7 @@
 # System
-from pathlib import Path
 import numpy as np
 
 # OCC
-from occwl.solid import Solid
 from occwl.uvgrid import uvgrid, ugrid, _uvgrid_reverse_u
 
 # Test

--- a/tests/test_load_step_with_attributes.py
+++ b/tests/test_load_step_with_attributes.py
@@ -1,6 +1,3 @@
-# System
-from pathlib import Path
-
 # OCC
 from occwl.compound import Compound
 

--- a/tests/test_reduce_native_file_size.py
+++ b/tests/test_reduce_native_file_size.py
@@ -6,11 +6,9 @@ the triangles
 # System
 from pathlib import Path
 import tempfile
-import numpy as np
 
 # OCC
 from occwl.compound import Compound
-from OCC.Core import PYTHONOCC_VERSION_MAJOR, PYTHONOCC_VERSION_MINOR
 
 # Test
 from tests.test_base import TestBase

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -1,8 +1,6 @@
 # System
 import numpy as np
 
-from occwl.solid import Solid
-
 # Test
 from tests.test_base import TestBase
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,8 +5,6 @@ Test the transform() function
 # System
 import numpy as np
 
-from occwl.solid import Solid
-
 # Test
 from tests.test_base import TestBase
 

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from occwl.vertex import Vertex
-
 # Test
 from tests.test_base import TestBase
 


### PR DESCRIPTION
This PR updates pythonocc-core from v7.5.1 to v7.8.1.
This required
- updates to conda environment definitions
- replace removed `.Nodes().Value(idx)` functions with `.Node(idx)`.
- Replace a number of functions with static methods to avoid deprecation warnings.

As a bonus, I have removed numerous unused imports.