### PR TITLE
Bugfix: correct array dimension in transform check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="occwl",  # package name
-    version="2.1.0",
+    version="2.1.1",
     author="Pradeep Kumar Jayaraman, Joseph G. Lambourne",
     author_email="pradeep.kumar.jayaraman@autodesk.com, joseph.lambourne@autodesk.com",
     description="Lightweight Pythonic wrapper around pythonocc",

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -397,9 +397,9 @@ class Shape:
                 vertex.Location(identity)
         
 
-    def transform(self, a, copy=True):
+    def transform(self, a: np.ndarray, copy=True):
         """
-        Apply the given 4x4 transform matrix to the solid
+        Apply the given 3x4 transform matrix to the solid.
 
         Args: a (nd.array) - Homogeneous transform matrix
                              The transform that will be applied is
@@ -413,6 +413,7 @@ class Shape:
                             False - Apply the transform to the topods Locator
                                     if possible 
         """
+        assert (a.shape == (3, 4)), "Transform matrix must be 3x4"
         a = a.astype(np.float64)
 
         # Create an identity transform

--- a/src/occwl/shape.py
+++ b/src/occwl/shape.py
@@ -422,7 +422,7 @@ class Shape:
         # we don't want to set the values as this
         # would give us a geometric identity without
         # the identity flag set
-        if not np.allclose(a, np.eye(4)):
+        if not np.allclose(a, np.eye(3, 4)):
             trsf.SetValues(
                 a[0,0], a[0,1], a[0,2], a[0, 3],
                 a[1,0], a[1,1], a[1,2], a[1, 3],

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -55,12 +55,21 @@ class SplitClosedEdgeSolidTester(TestBase):
 class TransformTester(TestBase):
     def test_smoke(self):
         box = Solid.make_box(1, 1, 1)
-        print("running")
-        transformed_box = box.transform(
-            np.array([
-                [1, 0, 0, 0],
-                [0, 1, 0, 0],
-                [0, 0, 1, 0],
-            ]),
-            copy=True,
-        )
+        with self.subTest("identity"):
+            box.transform(
+                np.array([
+                    [1, 0, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 1, 0],
+                ]),
+                copy=True,
+            )
+        with self.subTest("nonidentity"):
+            box.transform(
+                np.array([
+                    [0, 1, 0, 1.],
+                    [0, 0, 1, 2.],
+                    [1, 0, 0, 3.],
+                ]),
+                copy=True,
+            )

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -51,3 +51,16 @@ class SplitClosedEdgeSolidTester(TestBase):
         self.assertTrue(split_solid is not None)
         num_edges_after_splitting = split_solid.num_edges()
         self.assertLessEqual(num_original_edges, num_edges_after_splitting)
+
+class TransformTester(TestBase):
+    def test_smoke(self):
+        box = Solid.make_box(1, 1, 1)
+        print("running")
+        transformed_box = box.transform(
+            np.array([
+                [1, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 1, 0],
+            ]),
+            copy=True,
+        )


### PR DESCRIPTION
# What?
This PR corrects a bug in an array comparison in the `Shape.transform` method.

Two regression smoke tests are also added to ensure this method runs through.

# Why?
In the `Shape.transform` method, a comparison is performed to check for the identity transform. Currently, this has mismatching dimensions with the expected transform array resulting in the following error:
```
ValueError: operands could not be broadcast together with shapes (3,4) (4,4)
```
This renders this method unusable.