### PR TITLE
Update to version 3.0.0 in meta.yml

### DIFF
--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "occwl" %}
-{% set version = "2.1.0" %}
+{% set version = "3.0.0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="occwl",  # package name
-    version="2.1.1",
+    version="3.0.0",
     author="Pradeep Kumar Jayaraman, Joseph G. Lambourne",
     author_email="pradeep.kumar.jayaraman@autodesk.com, joseph.lambourne@autodesk.com",
     description="Lightweight Pythonic wrapper around pythonocc",


### PR DESCRIPTION
# Why?
In #37 the requirement for a 3x4 matrix in the transform was clarified.   While this doesn't change the API, it changes the preconditions on the function.   I'm updating the major version to reflect this