### PR TITLE
Documentation page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install mkdocs mkdocs-material mkdocstrings[python]
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ results/*
 
 # Mac meta-data files
 .DS_Store
+
+.idea/**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCC Wrapper Library
 
-[![Docs](https://img.shields.io/badge/docs-online-orange)](https://pradeep-pyro.github.io/occwl/)
+[![Docs](https://img.shields.io/badge/docs-online-orange)](https://AutodeskAILab.github.io/occwl)
 
 OCCWL is a simple, lightweight Pythonic wrapper around pythonocc (python bindings for OpenCascade).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OCC Wrapper Library
 
+[![Docs](https://img.shields.io/badge/docs-online-orange)](https://pradeep-pyro.github.io/occwl/)
+
 OCCWL is a simple, lightweight Pythonic wrapper around pythonocc (python bindings for OpenCascade).
 
 ## Installing our conda package

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,7 @@
+# API Reference
+
+::: occwl
+    handler: python
+    options:
+      show_submodules: true
+      inherited_members: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# OCCWL Wrapper Library (occwl)
+→ [API Documentation](api.md)
+
+→ [Developer's Guide](occwl_developers_guide.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: OCC Wrapper Library (occwl)
+theme:
+  name: material
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+
+setup_commands:
+  - import sys; sys.path.insert(0, "src")
+
+nav:
+  - Home: index.md
+  - API Documentation: api.md
+  - Developers Guide: occwl_developers_guide.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,10 @@
 site_name: OCC Wrapper Library (occwl)
 theme:
   name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - toc.integrate
 
 plugins:
   - search


### PR DESCRIPTION
Add automatic documentation pages using MkDocs. There's a Github action set up to auto-update and publish the page when there's a push to the repo.

Link to docs here: https://autodeskailab.github.io/occwl/